### PR TITLE
Add fan-only mode as a separate switch on each thermostat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,11 +316,13 @@ See `API-EXPLORATION-FINDINGS.md` for full field reference including `profile_up
 
 HomeKit's `Thermostat` service has no fan-only target state, so we expose a second `Switch` service per accessory (subtype `fan-only`).
 
-- **Switch ON** → `sendCommand({ operationMode: 'vent' })`
-- **Switch OFF** → `sendCommand({ operationMode: 'off' })` — turns the unit off entirely
+- **Capability-gated:** the switch is only added once the device profile reports `hasModeVent === true`. If a cached accessory carries a switch but the profile reports no vent support, it's removed.
+- **Switch ON** → `sendCommand({ operationMode: 'vent', power: 1 })`
+- **Switch OFF** → `sendCommand({ operationMode: 'off', power: 0 })` — turns the unit off entirely
+- The `power` field is sent explicitly on the fan path to match the verified v3 cloud reference ([EnumC/ha_kumo_ws](https://github.com/EnumC/ha_kumo_ws)); the existing HEAT/COOL/AUTO path still omits `power` since the API derives it from a non-off `operationMode`.
 - The switch is kept in sync with streaming/polling updates: ON iff `power === 1 && operationMode === 'vent'`.
 - Changing the thermostat to HEAT / COOL / AUTO / OFF optimistically flips the switch off; engaging the switch optimistically sets the thermostat to OFF (since HomeKit's thermostat service can't represent fan-only).
-- Code: `accessory.ts:setupFanOnlySwitch / setFanOnlyOn / isFanOnlyActive`
+- Code: `accessory.ts:setupFanOnlySwitch / removeFanOnlySwitch / setFanOnlyOn / isFanOnlyActive`
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,17 @@ See `API-EXPLORATION-FINDINGS.md` for full field reference including `profile_up
 | CurrentRelativeHumidity | humidity | Optional sensor |
 | FilterChangeIndication | displayConfig.filter | From streaming only |
 | Model (AccessoryInformation) | modelNumber | Set once from streaming |
+| Switch "Fan" (On) | operationMode === 'vent' && power === 1 | Separate `Switch` service; ON sends `vent`, OFF sends `off` (powers the unit down) |
+
+### Fan-only switch
+
+HomeKit's `Thermostat` service has no fan-only target state, so we expose a second `Switch` service per accessory (subtype `fan-only`).
+
+- **Switch ON** → `sendCommand({ operationMode: 'vent' })`
+- **Switch OFF** → `sendCommand({ operationMode: 'off' })` — turns the unit off entirely
+- The switch is kept in sync with streaming/polling updates: ON iff `power === 1 && operationMode === 'vent'`.
+- Changing the thermostat to HEAT / COOL / AUTO / OFF optimistically flips the switch off; engaging the switch optimistically sets the thermostat to OFF (since HomeKit's thermostat service can't represent fan-only).
+- Code: `accessory.ts:setupFanOnlySwitch / setFanOnlyOn / isFanOnlyActive`
 
 ## Development Notes
 
@@ -352,7 +363,7 @@ Logs location: `/var/lib/homebridge/homebridge.log`
 1. ~~**Conditional polling:** Only poll when streaming disconnected~~ ✅ **Implemented in v1.3.0**
 2. **Better error handling:** More graceful degradation when API unavailable
 3. **Humidity sensor:** Automatically add humidity sensor accessory when available
-4. **Fan mode:** Support fan-only mode (currently mapped to COOL)
+4. ~~**Fan mode:** Support fan-only mode~~ ✅ Exposed as a separate `Switch` service per accessory
 5. **Config UI:** Add streaming status indicator in Homebridge UI
 
 ## Important Files Reference

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.3.6",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.3.6",
+      "version": "1.3.8",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -64,7 +64,19 @@ export class KumoThermostatAccessory {
     // Note: Polling is now handled at the platform level (centralized site polling)
     // This accessory will receive updates via updateFromZone()
 
-    this.setupFanOnlySwitch();
+    // If this accessory was cached with a fan-only switch from a previous run,
+    // wire up its handlers immediately. applyDeviceProfile() will remove it if
+    // the device profile later reports hasModeVent === false.
+    const cachedFanSwitch = this.accessory.getServiceById(
+      this.platform.Service.Switch,
+      'fan-only',
+    );
+    if (cachedFanSwitch) {
+      this.fanOnlyService = cachedFanSwitch;
+      this.fanOnlyService.getCharacteristic(this.platform.Characteristic.On)
+        .onGet(this.getFanOnlyOn.bind(this))
+        .onSet(this.setFanOnlyOn.bind(this));
+    }
 
     // Register for streaming updates
     this.kumoAPI.subscribeToDevice(this.deviceSerial, this.handleStreamingUpdate.bind(this));
@@ -106,9 +118,20 @@ export class KumoThermostatAccessory {
     this.platform.log.info(
       `${this.accessory.displayName}: Set temperature range ${minTemp}-${maxTemp}°C (${minTempF}-${maxTempF}°F)`,
     );
+
+    // Add / remove the fan-only switch based on device capability
+    if (profile.hasModeVent) {
+      this.setupFanOnlySwitch();
+    } else {
+      this.removeFanOnlySwitch();
+    }
   }
 
   private setupFanOnlySwitch(): void {
+    if (this.fanOnlyService) {
+      return;
+    }
+
     const displayName = this.accessory.context.device.displayName;
     const switchName = `${displayName} Fan`;
 
@@ -122,6 +145,25 @@ export class KumoThermostatAccessory {
     this.fanOnlyService.getCharacteristic(this.platform.Characteristic.On)
       .onGet(this.getFanOnlyOn.bind(this))
       .onSet(this.setFanOnlyOn.bind(this));
+
+    // Reflect current state immediately if we already have a status
+    this.fanOnlyService.updateCharacteristic(
+      this.platform.Characteristic.On,
+      this.isFanOnlyActive(this.currentStatus),
+    );
+
+    this.platform.log.debug(`Added Fan-Only switch for ${this.accessory.displayName}`);
+  }
+
+  private removeFanOnlySwitch(): void {
+    const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'fan-only');
+    if (existing) {
+      this.accessory.removeService(existing);
+      this.platform.log.debug(
+        `Removed Fan-Only switch for ${this.accessory.displayName} (device reports no vent mode support)`,
+      );
+    }
+    this.fanOnlyService = null;
   }
 
   private isFanOnlyActive(status: DeviceStatus | null): boolean {
@@ -138,12 +180,13 @@ export class KumoThermostatAccessory {
   async setFanOnlyOn(value: CharacteristicValue): Promise<void> {
     const on = value as boolean;
     const operationMode: 'vent' | 'off' = on ? 'vent' : 'off';
+    const power: 0 | 1 = on ? 1 : 0;
 
     this.platform.log.info(
       `[FAN ONLY] ${this.accessory.displayName}: HomeKit sent ${on ? 'ON' : 'OFF'}`,
     );
 
-    const success = await this.kumoAPI.sendCommand(this.deviceSerial, { operationMode });
+    const success = await this.kumoAPI.sendCommand(this.deviceSerial, { operationMode, power });
 
     if (!success) {
       this.platform.log.error(

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -17,6 +17,7 @@ export class KumoThermostatAccessory {
   private hasReceivedValidUpdate: boolean = false;
   private deviceProfile: DeviceProfile | null = null;
   private filterMaintenanceService: Service | null = null;
+  private fanOnlyService: Service | null = null;
   private modelNumberSet: boolean = false;
 
   constructor(
@@ -63,6 +64,8 @@ export class KumoThermostatAccessory {
     // Note: Polling is now handled at the platform level (centralized site polling)
     // This accessory will receive updates via updateFromZone()
 
+    this.setupFanOnlySwitch();
+
     // Register for streaming updates
     this.kumoAPI.subscribeToDevice(this.deviceSerial, this.handleStreamingUpdate.bind(this));
     this.platform.log.debug(`Registered streaming callback for ${this.deviceSerial}`);
@@ -102,6 +105,76 @@ export class KumoThermostatAccessory {
     const maxTempF = (maxTemp * 9 / 5) + 32;
     this.platform.log.info(
       `${this.accessory.displayName}: Set temperature range ${minTemp}-${maxTemp}°C (${minTempF}-${maxTempF}°F)`,
+    );
+  }
+
+  private setupFanOnlySwitch(): void {
+    const displayName = this.accessory.context.device.displayName;
+    const switchName = `${displayName} Fan`;
+
+    this.fanOnlyService =
+      this.accessory.getServiceById(this.platform.Service.Switch, 'fan-only') ||
+      this.accessory.addService(this.platform.Service.Switch, switchName, 'fan-only');
+
+    this.fanOnlyService.setCharacteristic(this.platform.Characteristic.Name, switchName);
+    this.fanOnlyService.setCharacteristic(this.platform.Characteristic.ConfiguredName, switchName);
+
+    this.fanOnlyService.getCharacteristic(this.platform.Characteristic.On)
+      .onGet(this.getFanOnlyOn.bind(this))
+      .onSet(this.setFanOnlyOn.bind(this));
+  }
+
+  private isFanOnlyActive(status: DeviceStatus | null): boolean {
+    if (!status) {
+      return false;
+    }
+    return status.power === 1 && status.operationMode === 'vent';
+  }
+
+  async getFanOnlyOn(): Promise<CharacteristicValue> {
+    return this.isFanOnlyActive(this.currentStatus);
+  }
+
+  async setFanOnlyOn(value: CharacteristicValue): Promise<void> {
+    const on = value as boolean;
+    const operationMode: 'vent' | 'off' = on ? 'vent' : 'off';
+
+    this.platform.log.info(
+      `[FAN ONLY] ${this.accessory.displayName}: HomeKit sent ${on ? 'ON' : 'OFF'}`,
+    );
+
+    const success = await this.kumoAPI.sendCommand(this.deviceSerial, { operationMode });
+
+    if (!success) {
+      this.platform.log.error(
+        `[FAN ONLY] ${this.accessory.displayName}: Failed to set fan-only ${on ? 'ON' : 'OFF'}`,
+      );
+      // Revert the switch to the actual device state
+      setTimeout(() => {
+        this.fanOnlyService?.updateCharacteristic(
+          this.platform.Characteristic.On,
+          this.isFanOnlyActive(this.currentStatus),
+        );
+      }, 100);
+      return;
+    }
+
+    this.platform.log.info(`[FAN ONLY] ${this.accessory.displayName}: Command accepted by API`);
+
+    // Optimistic local-state update so the thermostat tile reflects the change immediately
+    if (this.currentStatus) {
+      this.currentStatus.operationMode = operationMode;
+      this.currentStatus.power = on ? 1 : 0;
+    }
+
+    // Both vent and off map to HomeKit OFF on the thermostat service
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.CurrentHeatingCoolingState,
+      this.platform.Characteristic.CurrentHeatingCoolingState.OFF,
+    );
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.TargetHeatingCoolingState,
+      this.platform.Characteristic.TargetHeatingCoolingState.OFF,
     );
   }
 
@@ -304,6 +377,14 @@ export class KumoThermostatAccessory {
           status.humidity,
         );
       }
+
+      // Keep the fan-only switch in sync with the underlying device mode
+      if (this.fanOnlyService) {
+        this.fanOnlyService.updateCharacteristic(
+          this.platform.Characteristic.On,
+          this.isFanOnlyActive(status),
+        );
+      }
     } catch (error) {
       this.platform.log.error('Error updating device status:', error);
     }
@@ -443,6 +524,11 @@ export class KumoThermostatAccessory {
       if (this.currentStatus) {
         this.currentStatus.operationMode = operationMode;
         this.currentStatus.power = operationMode === 'off' ? 0 : 1;
+      }
+
+      // Picking any thermostat mode leaves fan-only inactive
+      if (this.fanOnlyService) {
+        this.fanOnlyService.updateCharacteristic(this.platform.Characteristic.On, false);
       }
 
       // Note: Platform will update on next poll cycle (no per-device polling timer)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -105,6 +105,7 @@ export interface Commands {
   spCool?: number;
   operationMode?: 'off' | 'heat' | 'cool' | 'auto' | 'vent' | 'dry';
   fanSpeed?: 'auto' | 'low' | 'medium' | 'high';
+  power?: 0 | 1;
 }
 
 export interface SendCommandRequest {


### PR DESCRIPTION
## Summary

HomeKit's `Thermostat` service has no fan-only target state, so each accessory now exposes a second `Switch` service (subtype `fan-only`) that surfaces alongside the thermostat tile.

- **Switch ON** → `sendCommand({ operationMode: 'vent' })`
- **Switch OFF** → `sendCommand({ operationMode: 'off' })` — powers the unit down entirely (per request)
- State is kept in sync from streaming/polling: the switch reads ON iff `power === 1 && operationMode === 'vent'`
- Picking HEAT / COOL / AUTO / OFF on the thermostat optimistically flips the switch off; engaging the switch optimistically sets the thermostat to OFF (since HomeKit's thermostat service can't represent vent)
- Failed commands revert the switch to the device's actual state

## Implementation

- `src/accessory.ts`: new `setupFanOnlySwitch` / `getFanOnlyOn` / `setFanOnlyOn` / `isFanOnlyActive`, plus sync points in `processZoneUpdate` and `setTargetHeatingCoolingState`
- `CLAUDE.md`: documented the new HomeKit mapping and behavior; struck the matching entry from "Future Improvements"

## Test plan

- [ ] Build succeeds (`npm run build`) — verified locally
- [ ] Restart Homebridge and confirm a new `Fan` switch appears on each thermostat tile
- [ ] Toggle the switch ON → unit reports `operationMode: 'vent'` and starts moving air without heating/cooling
- [ ] Toggle the switch OFF → unit fully powers off
- [ ] Change the thermostat to HEAT/COOL/AUTO via HomeKit → fan switch flips off automatically
- [ ] Change mode at the wall remote/Kumo app → switch state catches up on the next streaming update
- [ ] On a unit without vent support, confirm the API rejection is logged cleanly (no UI lockup)

---
_Generated by [Claude Code](https://claude.ai/code/session_017qgZ8ZRECzZWbxwwBB66aa)_