### PR TITLE
Stabilize humidity characteristic and document v3 API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,17 +183,27 @@ JWT tokens expire every 20 minutes. We handle this with:
 
 ### Kumo Cloud v3 API Endpoints
 
-**Base URL:** `https://app-api.kumocloud.com/v3`
+**Base URL:** `https://app-prod.kumocloud.com/v3`
+
+**Required Headers:**
+- `Authorization: Bearer <access-token>` (all authenticated requests)
+- `X-App-Version: 3.2.4` (all requests; constant in `settings.ts`)
 
 **Authentication:**
-- `POST /login` - Returns access and refresh tokens
+- `POST /login` - Returns access and refresh tokens (plus user profile: id, email, etc.)
 - `POST /refresh` - Refreshes access token
 
 **Data Retrieval:**
+- `GET /accounts/me` - Account info (similar to login response)
 - `GET /sites` - List all sites (homes)
-- `GET /sites/{siteId}/zones` - Get all zones for a site
+- `GET /sites/{siteId}/zones` - Get all zones for a site (includes nested `group` and `adapter` objects)
   - Returns full device status for each zone
   - This is the primary polling endpoint
+- `GET /sites/{siteId}/groups` - System changeover groups (minRuntime, maxStandby)
+- `GET /devices/{serial}` - Full device info (includes `model` object with brand, gallery image)
+- `GET /devices/{serial}/profile` - Device capabilities (modes, fan speeds, setpoint limits)
+- `GET /devices/{serial}/status` - Connection status, `cryptoSerial`, `firmwareVersion`, `autoModeDisable`
+- `GET /devices/{serial}/kumo-properties` - Reporting, `outdoorAirTemperature`, `heatModeDisable`
 
 **Commands:**
 - `POST /devices/send-command` - Send command to device
@@ -233,7 +243,7 @@ JWT tokens expire every 20 minutes. We handle this with:
   spCool: number
   spAuto: number | null
   power: 0 | 1
-  operationMode: 'off' | 'heat' | 'cool' | 'auto' | 'vent' | 'dry'
+  operationMode: 'off' | 'heat' | 'cool' | 'auto' | 'autoHeat' | 'autoCool' | 'vent' | 'dry'
   fanSpeed: string
   airDirection: string
   humidity: number | null
@@ -252,6 +262,10 @@ JWT tokens expire every 20 minutes. We handle this with:
   // unusualFigures, statusDisplay, runTest, lastStatusChangeAt, createdAt, updatedAt, timeZone
 }
 ```
+
+**Note on `operationMode`:** When *sending* commands, use `'auto'`. The API *returns* `'autoHeat'` or `'autoCool'` to indicate which sub-mode auto is currently in. The code handles this via `startsWith('auto')` in `accessory.ts`.
+
+**Note on `autoModeDisable`:** The `/devices/{serial}/status` endpoint returns `autoModeDisable: true` for units that don't support auto mode at the hardware level. This explains why `spAuto` is null for some devices.
 
 **Field documentation sourced from:** [dlarrick/hass-kumo](https://github.com/dlarrick/hass-kumo),
 [EnumC/ha_kumo_ws](https://github.com/EnumC/ha_kumo_ws), and

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -258,7 +258,7 @@ export class KumoThermostatAccessory {
         spHeat: data.spHeat!,
         spCool: data.spCool!,
         spAuto: data.spAuto || null,
-        humidity: data.humidity || null,
+        humidity: data.humidity ?? null,
         power: data.power!,
         operationMode: data.operationMode!,
         previousOperationMode: data.operationMode!,
@@ -351,16 +351,11 @@ export class KumoThermostatAccessory {
         this.service.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
           .onGet(this.getCurrentRelativeHumidity.bind(this));
         this.platform.log.debug(`Added humidity characteristic for device ${this.deviceSerial}`);
-      } else if (!hasHumidity && this.hasHumiditySensor) {
-        // Device no longer has humidity sensor - remove the characteristic
-        this.hasHumiditySensor = false;
-        if (this.service.testCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)) {
-          this.service.removeCharacteristic(
-            this.service.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity),
-          );
-          this.platform.log.debug(`Removed humidity characteristic for device ${this.deviceSerial}`);
-        }
       }
+      // Note: Once humidity is detected, we never remove the characteristic.
+      // Streaming updates may intermittently omit humidity data, but that doesn't
+      // mean the hardware sensor is gone. Toggling the characteristic destabilizes
+      // HomeKit and causes "No Response" errors.
 
       // Convert adapter data to DeviceStatus format
       const status: DeviceStatus = {


### PR DESCRIPTION
## Changes

### src/accessory.ts
- Use nullish coalescing for `humidity` so a valid reading of `0` is preserved instead of coerced to `null`.
- Stop removing `CurrentRelativeHumidity` when an update omits humidity data. Streaming updates intermittently drop the field, and toggling the characteristic causes HomeKit "No Response" errors. Once the sensor is detected, it stays registered.

### CLAUDE.md
- Correct the v3 base URL to `app-prod.kumocloud.com` and document the required `Authorization` / `X-App-Version` headers.
- Document additional endpoints discovered during exploration (`/accounts/me`, `/sites/{id}/groups`, `/devices/{serial}` plus `profile`/`status`/`kumo-properties` variants).
- Note that the API returns `autoHeat` / `autoCool` while commands send plain `auto`, and document `autoModeDisable` behaviour.

## Test plan
- Builds cleanly (`npm run build`).
- Deployed on Pi prior to PR; humidity sensor no longer flickers offline during intermittent streaming gaps.

Co-Authored-By: Oz <oz-agent@warp.dev>