### PR TITLE
Expose Dry mode as a Switch (mirrors fan-only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides context about the homebridge-mitsubishi-comfort plugin ar
 
 This is a Homebridge plugin for Mitsubishi heat pumps using the Kumo Cloud v3 API. It provides HomeKit integration for controlling Mitsubishi mini-split systems.
 
-**Current Version:** 1.4.1
+**Current Version:** 1.5.0
 
 ## Architecture Overview
 
@@ -325,6 +325,7 @@ See `API-EXPLORATION-FINDINGS.md` for full field reference including `profile_up
 | FilterChangeIndication | displayConfig.filter | From streaming only |
 | Model (AccessoryInformation) | modelNumber | Set once from streaming |
 | Switch "Fan" (On) | operationMode === 'vent' && power === 1 | Separate `Switch` service; ON sends `vent`, OFF sends `off` (powers the unit down) |
+| Switch "Dry" (On) | operationMode === 'dry' && power === 1 | Separate `Switch` service; ON sends `dry`, OFF sends `off`. Capability-gated on `hasModeDry`. Mutually exclusive with the Fan switch |
 
 ### Fan-only switch
 
@@ -337,6 +338,18 @@ HomeKit's `Thermostat` service has no fan-only target state, so we expose a seco
 - The switch is kept in sync with streaming/polling updates: ON iff `power === 1 && operationMode === 'vent'`.
 - Changing the thermostat to HEAT / COOL / AUTO / OFF optimistically flips the switch off; engaging the switch optimistically sets the thermostat to OFF (since HomeKit's thermostat service can't represent fan-only).
 - Code: `accessory.ts:setupFanOnlySwitch / removeFanOnlySwitch / setFanOnlyOn / isFanOnlyActive`
+
+### Dry switch
+
+HomeKit's `Thermostat` service has no dehumidify target state either, so dry is surfaced the same way as fan-only: a separate `Switch` service per accessory (subtype `dry`).
+
+- **Capability-gated:** added only once the device profile reports `hasModeDry === true` (a real top-level field in the v3 profile payload — see `API-EXPLORATION-FINDINGS.md`). A cached switch on a device that reports no dry support is removed.
+- **Switch ON** → `sendCommand({ operationMode: 'dry', power: 1 })`
+- **Switch OFF** → `sendCommand({ operationMode: 'off', power: 0 })` — turns the unit off entirely
+- The switch is kept in sync with streaming/polling updates: ON iff `power === 1 && operationMode === 'dry'`.
+- **Mutually exclusive with fan-only:** engaging dry optimistically flips the Fan switch off, and engaging fan-only flips the Dry switch off; changing the thermostat to HEAT / COOL / AUTO / OFF flips both off. Streaming/polling reconciles as the authoritative backstop. The optimistic cross-flip is unconditional because a successful command always leaves the unit in this switch's mode or `off` — never the sibling's mode.
+- **Setpoint limitation:** some units report `usesSetPointInDryMode === true`, meaning they accept a target while dehumidifying. An on/off switch can't express that, so dry runs at the unit's default setpoint (same inherent HomeKit constraint as fan having no speed). While dry is active the thermostat tile shows OFF.
+- Code: `accessory.ts:setupDrySwitch / removeDrySwitch / setDryOn / isDryActive`
 
 ## Development Notes
 
@@ -403,6 +416,13 @@ When making changes, verify:
 
 ## Version History
 
+- **1.5.0** - Dry (dehumidify) mode as a Switch (June 2026)
+  - Exposes dry mode as a separate `Switch` service per thermostat (subtype `dry`), mirroring the fan-only switch (#14)
+  - Capability-gated on `profile.hasModeDry`; a cached switch is removed if the device reports no dry support
+  - Switch ON → `sendCommand({ operationMode: 'dry', power: 1 })`; OFF → `{ operationMode: 'off', power: 0 }`
+  - Fan-only and dry are mutually exclusive: engaging one optimistically flips the other off, with streaming/polling as the backstop
+  - HomeKit's Thermostat service has no dehumidify state, so (like fan-only) the thermostat shows OFF while dry is active; the unit's dry setpoint (`usesSetPointInDryMode`) can't be exposed through an on/off switch
+  - Code: `accessory.ts:setupDrySwitch / removeDrySwitch / setDryOn / isDryActive`
 - **1.4.1** - Self-healing device discovery (May 2026)
   - Fixed: a transient login/network failure at startup (e.g. a DNS blip) left the plugin idle until a manual restart — `discoverDevices()` logged the error and returned with no retry, so streaming never started
   - `discoverDevices()` now retries with exponential backoff (30s → 5min cap) and keeps retrying indefinitely, recovering on its own once connectivity returns

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Homebridge plugin for Mitsubishi heat pumps using Kumo Cloud v3 API",
   "author": "burtherman",
   "main": "dist/index.js",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -241,6 +241,12 @@ export class KumoThermostatAccessory {
       this.platform.Characteristic.TargetHeatingCoolingState,
       this.platform.Characteristic.TargetHeatingCoolingState.OFF,
     );
+
+    // Fan-only and dry are mutually exclusive — engaging fan-only means the
+    // unit is no longer dehumidifying, so flip the dry switch off optimistically.
+    if (this.dryService) {
+      this.dryService.updateCharacteristic(this.platform.Characteristic.On, false);
+    }
   }
 
   private setupDrySwitch(): void {
@@ -335,6 +341,12 @@ export class KumoThermostatAccessory {
       this.platform.Characteristic.TargetHeatingCoolingState,
       this.platform.Characteristic.TargetHeatingCoolingState.OFF,
     );
+
+    // Fan-only and dry are mutually exclusive — engaging dry means the unit is
+    // no longer fan-only, so flip the fan switch off optimistically.
+    if (this.fanOnlyService) {
+      this.fanOnlyService.updateCharacteristic(this.platform.Characteristic.On, false);
+    }
   }
 
   private updateFilterMaintenance(filterDirty: boolean): void {

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -18,6 +18,7 @@ export class KumoThermostatAccessory {
   private deviceProfile: DeviceProfile | null = null;
   private filterMaintenanceService: Service | null = null;
   private fanOnlyService: Service | null = null;
+  private dryService: Service | null = null;
   private modelNumberSet: boolean = false;
 
   constructor(
@@ -78,6 +79,18 @@ export class KumoThermostatAccessory {
         .onSet(this.setFanOnlyOn.bind(this));
     }
 
+    // Same for a cached dry switch (see setupDrySwitch / hasModeDry).
+    const cachedDrySwitch = this.accessory.getServiceById(
+      this.platform.Service.Switch,
+      'dry',
+    );
+    if (cachedDrySwitch) {
+      this.dryService = cachedDrySwitch;
+      this.dryService.getCharacteristic(this.platform.Characteristic.On)
+        .onGet(this.getDryOn.bind(this))
+        .onSet(this.setDryOn.bind(this));
+    }
+
     // Register for streaming updates
     this.kumoAPI.subscribeToDevice(this.deviceSerial, this.handleStreamingUpdate.bind(this));
     this.platform.log.debug(`Registered streaming callback for ${this.deviceSerial}`);
@@ -124,6 +137,15 @@ export class KumoThermostatAccessory {
       this.setupFanOnlySwitch();
     } else {
       this.removeFanOnlySwitch();
+    }
+
+    // Add / remove the dry switch based on device capability. HomeKit's
+    // Thermostat can't represent dehumidify, so — exactly like fan-only —
+    // dry is surfaced as a separate Switch.
+    if (profile.hasModeDry) {
+      this.setupDrySwitch();
+    } else {
+      this.removeDrySwitch();
     }
   }
 
@@ -211,6 +233,100 @@ export class KumoThermostatAccessory {
     }
 
     // Both vent and off map to HomeKit OFF on the thermostat service
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.CurrentHeatingCoolingState,
+      this.platform.Characteristic.CurrentHeatingCoolingState.OFF,
+    );
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.TargetHeatingCoolingState,
+      this.platform.Characteristic.TargetHeatingCoolingState.OFF,
+    );
+  }
+
+  private setupDrySwitch(): void {
+    if (this.dryService) {
+      return;
+    }
+
+    const displayName = this.accessory.context.device.displayName;
+    const switchName = `${displayName} Dry`;
+
+    this.dryService =
+      this.accessory.getServiceById(this.platform.Service.Switch, 'dry') ||
+      this.accessory.addService(this.platform.Service.Switch, switchName, 'dry');
+
+    this.dryService.setCharacteristic(this.platform.Characteristic.Name, switchName);
+    this.dryService.setCharacteristic(this.platform.Characteristic.ConfiguredName, switchName);
+
+    this.dryService.getCharacteristic(this.platform.Characteristic.On)
+      .onGet(this.getDryOn.bind(this))
+      .onSet(this.setDryOn.bind(this));
+
+    // Reflect current state immediately if we already have a status
+    this.dryService.updateCharacteristic(
+      this.platform.Characteristic.On,
+      this.isDryActive(this.currentStatus),
+    );
+
+    this.platform.log.debug(`Added Dry switch for ${this.accessory.displayName}`);
+  }
+
+  private removeDrySwitch(): void {
+    const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'dry');
+    if (existing) {
+      this.accessory.removeService(existing);
+      this.platform.log.debug(
+        `Removed Dry switch for ${this.accessory.displayName} (device reports no dry mode support)`,
+      );
+    }
+    this.dryService = null;
+  }
+
+  private isDryActive(status: DeviceStatus | null): boolean {
+    if (!status) {
+      return false;
+    }
+    return status.power === 1 && status.operationMode === 'dry';
+  }
+
+  async getDryOn(): Promise<CharacteristicValue> {
+    return this.isDryActive(this.currentStatus);
+  }
+
+  async setDryOn(value: CharacteristicValue): Promise<void> {
+    const on = value as boolean;
+    const operationMode: 'dry' | 'off' = on ? 'dry' : 'off';
+    const power: 0 | 1 = on ? 1 : 0;
+
+    this.platform.log.info(
+      `[DRY] ${this.accessory.displayName}: HomeKit sent ${on ? 'ON' : 'OFF'}`,
+    );
+
+    const success = await this.kumoAPI.sendCommand(this.deviceSerial, { operationMode, power });
+
+    if (!success) {
+      this.platform.log.error(
+        `[DRY] ${this.accessory.displayName}: Failed to set dry ${on ? 'ON' : 'OFF'}`,
+      );
+      // Revert the switch to the actual device state
+      setTimeout(() => {
+        this.dryService?.updateCharacteristic(
+          this.platform.Characteristic.On,
+          this.isDryActive(this.currentStatus),
+        );
+      }, 100);
+      return;
+    }
+
+    this.platform.log.info(`[DRY] ${this.accessory.displayName}: Command accepted by API`);
+
+    // Optimistic local-state update so the thermostat tile reflects the change immediately
+    if (this.currentStatus) {
+      this.currentStatus.operationMode = operationMode;
+      this.currentStatus.power = on ? 1 : 0;
+    }
+
+    // Both dry and off map to HomeKit OFF on the thermostat service
     this.service.updateCharacteristic(
       this.platform.Characteristic.CurrentHeatingCoolingState,
       this.platform.Characteristic.CurrentHeatingCoolingState.OFF,
@@ -423,6 +539,14 @@ export class KumoThermostatAccessory {
           this.isFanOnlyActive(status),
         );
       }
+
+      // Keep the dry switch in sync with the underlying device mode
+      if (this.dryService) {
+        this.dryService.updateCharacteristic(
+          this.platform.Characteristic.On,
+          this.isDryActive(status),
+        );
+      }
     } catch (error) {
       this.platform.log.error('Error updating device status:', error);
     }
@@ -564,9 +688,12 @@ export class KumoThermostatAccessory {
         this.currentStatus.power = operationMode === 'off' ? 0 : 1;
       }
 
-      // Picking any thermostat mode leaves fan-only inactive
+      // Picking any thermostat mode leaves fan-only and dry inactive
       if (this.fanOnlyService) {
         this.fanOnlyService.updateCharacteristic(this.platform.Characteristic.On, false);
+      }
+      if (this.dryService) {
+        this.dryService.updateCharacteristic(this.platform.Characteristic.On, false);
       }
 
       // Note: Platform will update on next poll cycle (no per-device polling timer)


### PR DESCRIPTION
## Problem

A unit physically in **Dry (dehumidify)** mode is invisible to anything reading the HAP endpoint. HomeKit's Thermostat service can't represent dehumidify — `TargetHeatingCoolingState` is limited to off/heat/cool/auto — so `mapToTargetHeatingCoolingState` / `mapToCurrentHeatingCoolingState` fall through to **OFF** for `'dry'`. The existing fan-only Switch only tracks `'vent'`, so Dry ends up indistinguishable from a genuinely-off unit (Current=0, Target=0, fan switch off).

Verified live against a real bridge: a zone set to Dry reported `Target=0, Current=0, fanSwitch=0` — identical to OFF — even though the device reports `operationMode === 'dry'` internally.

## Approach

Do for Dry exactly what the plugin already does for fan-only: surface it as a separate **Switch** service. This is the established escape hatch for modes HomeKit can't model on a Thermostat.

- New per-zone Switch, subtype `'dry'`, named `<zone> Dry`.
- Gated on the device's `hasModeDry` capability in `applyDeviceProfile` (same place `hasModeVent` gates the fan switch).
- `isDryActive` = `power === 1 && operationMode === 'dry'`.
- `setDryOn` sends `{ operationMode: 'dry' | 'off', power }`, with the same optimistic-update + failure-revert handling as `setFanOnlyOn`, and maps the thermostat to OFF (unchanged HomeKit behavior).
- Kept in sync everywhere the fan switch is: cache rehydration in the constructor, `processZoneUpdate`, and cleared when a thermostat mode is chosen in `setTargetHeatingCoolingState`.

The thermostat characteristics are untouched — Dry still reads OFF there (HomeKit constraint). The Switch is what makes Dry observable and controllable.

## What changed

- `src/accessory.ts` only (+128/-1). No `settings.ts` / `kumo-api.ts` changes — `Commands.operationMode` already includes `'dry'` and `DeviceProfile.hasModeDry` is already parsed.

## Verification

- `npm run build` — clean (tsc, no type errors).
- `npm test` — 5/5 pass (existing discovery-retry suite; no regressions).
- The new code is a line-for-line structural mirror of the already-shipped fan-only switch, which has no dedicated test either — happy to add a focused accessory-level test if the reviewer wants one.

## Downstream note

Consumers that read the HAP endpoint (e.g. a dashboard parsing `/accessories`) can now detect Dry by checking the zone's `'dry'` Switch `On` value, since the thermostat state alone can't distinguish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
