### PR TITLE
Publish runtime-added features to HomeKit (switches, humidity, filter)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides context about the homebridge-mitsubishi-comfort plugin ar
 
 This is a Homebridge plugin for Mitsubishi heat pumps using the Kumo Cloud v3 API. It provides HomeKit integration for controlling Mitsubishi mini-split systems.
 
-**Current Version:** 1.5.0
+**Current Version:** 1.5.1
 
 ## Architecture Overview
 
@@ -416,6 +416,13 @@ When making changes, verify:
 
 ## Version History
 
+- **1.5.1** - Publish runtime-added features to HomeKit (June 2026)
+  - Fixed: the fan-only switch (since 1.4.0), the dry switch (1.5.0), the humidity characteristic, and the filter indicator were all added to the accessory *after* it was published to the bridge (from async `profile_update` / first-reading callbacks) but never re-published — so they existed in memory and the HAP cache but never reached the Home app
+  - Root cause: no `api.updatePlatformAccessories([accessory])` call after a runtime structural change. Centralized in `accessory.ts:publishStructureChange()`, called at every add/remove site (switches, humidity, filter)
+  - `node:test` coverage extended (`test/switch-publish.test.js`) — asserts a re-publish happens on switch add/remove and on the first humidity reading; proven to fail against the pre-fix build
+  - **Operational caveat:** publishing the service is necessary but not always sufficient. HomeKit controllers cache an accessory's *service list* and only re-read it when the bridge's configuration number (`c#`) increases. iOS will not surface services added to an already-paired accessory until its cache is cleared — a full **device reboot** (clears the `homed` cache) or removing/re-adding the child bridge. Force-quitting the Home app or restarting a Home hub is not enough.
+  - Child bridge accessories persist to `accessories/cachedAccessories.<username-without-colons>` (e.g. `cachedAccessories.0EA3CB05C3A2`), NOT the main `cachedAccessories`
+  - Code: `accessory.ts:publishStructureChange and its 6 call sites`
 - **1.5.0** - Dry (dehumidify) mode as a Switch (June 2026)
   - Exposes dry mode as a separate `Switch` service per thermostat (subtype `dry`), mirroring the fan-only switch (#14)
   - Capability-gated on `profile.hasModeDry`; a cached switch is removed if the device reports no dry support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Homebridge plugin for Mitsubishi heat pumps using Kumo Cloud v3 API",
   "author": "burtherman",
   "main": "dist/index.js",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -149,6 +149,17 @@ export class KumoThermostatAccessory {
     }
   }
 
+  /**
+   * Re-publish this accessory to the bridge. REQUIRED after adding or removing a
+   * service or characteristic at runtime: the accessory was already published to
+   * HomeKit during discovery, so structural changes that happen later (a
+   * capability switch, the humidity characteristic, the filter service) never
+   * reach the Home app — or get persisted to the cache — without this call.
+   */
+  private publishStructureChange(): void {
+    this.platform.api.updatePlatformAccessories([this.accessory]);
+  }
+
   private setupFanOnlySwitch(): void {
     if (this.fanOnlyService) {
       return;
@@ -179,7 +190,7 @@ export class KumoThermostatAccessory {
     // has already been published to the bridge. A service added now is invisible
     // to HomeKit (and not persisted) unless we re-publish the accessory.
     if (!existing) {
-      this.platform.api.updatePlatformAccessories([this.accessory]);
+      this.publishStructureChange();
     }
 
     this.platform.log.debug(`Added Fan-Only switch for ${this.accessory.displayName}`);
@@ -189,7 +200,7 @@ export class KumoThermostatAccessory {
     const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'fan-only');
     if (existing) {
       this.accessory.removeService(existing);
-      this.platform.api.updatePlatformAccessories([this.accessory]);
+      this.publishStructureChange();
       this.platform.log.debug(
         `Removed Fan-Only switch for ${this.accessory.displayName} (device reports no vent mode support)`,
       );
@@ -288,7 +299,7 @@ export class KumoThermostatAccessory {
     // has already been published to the bridge. A service added now is invisible
     // to HomeKit (and not persisted) unless we re-publish the accessory.
     if (!existing) {
-      this.platform.api.updatePlatformAccessories([this.accessory]);
+      this.publishStructureChange();
     }
 
     this.platform.log.debug(`Added Dry switch for ${this.accessory.displayName}`);
@@ -298,7 +309,7 @@ export class KumoThermostatAccessory {
     const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'dry');
     if (existing) {
       this.accessory.removeService(existing);
-      this.platform.api.updatePlatformAccessories([this.accessory]);
+      this.publishStructureChange();
       this.platform.log.debug(
         `Removed Dry switch for ${this.accessory.displayName} (device reports no dry mode support)`,
       );
@@ -372,6 +383,7 @@ export class KumoThermostatAccessory {
       this.filterMaintenanceService =
         this.accessory.getService(this.platform.Service.FilterMaintenance) ||
         this.accessory.addService(this.platform.Service.FilterMaintenance);
+      this.publishStructureChange();
       this.platform.log.debug(`Added FilterMaintenance service for ${this.accessory.displayName}`);
     }
 
@@ -496,6 +508,7 @@ export class KumoThermostatAccessory {
         this.hasHumiditySensor = true;
         this.service.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
           .onGet(this.getCurrentRelativeHumidity.bind(this));
+        this.publishStructureChange();
         this.platform.log.debug(`Added humidity characteristic for device ${this.deviceSerial}`);
       }
       // Note: Once humidity is detected, we never remove the characteristic.

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -154,11 +154,12 @@ export class KumoThermostatAccessory {
       return;
     }
 
+    const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'fan-only');
     const displayName = this.accessory.context.device.displayName;
     const switchName = `${displayName} Fan`;
 
     this.fanOnlyService =
-      this.accessory.getServiceById(this.platform.Service.Switch, 'fan-only') ||
+      existing ||
       this.accessory.addService(this.platform.Service.Switch, switchName, 'fan-only');
 
     this.fanOnlyService.setCharacteristic(this.platform.Characteristic.Name, switchName);
@@ -174,6 +175,13 @@ export class KumoThermostatAccessory {
       this.isFanOnlyActive(this.currentStatus),
     );
 
+    // The profile arrives via an async streaming event, after the accessory
+    // has already been published to the bridge. A service added now is invisible
+    // to HomeKit (and not persisted) unless we re-publish the accessory.
+    if (!existing) {
+      this.platform.api.updatePlatformAccessories([this.accessory]);
+    }
+
     this.platform.log.debug(`Added Fan-Only switch for ${this.accessory.displayName}`);
   }
 
@@ -181,6 +189,7 @@ export class KumoThermostatAccessory {
     const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'fan-only');
     if (existing) {
       this.accessory.removeService(existing);
+      this.platform.api.updatePlatformAccessories([this.accessory]);
       this.platform.log.debug(
         `Removed Fan-Only switch for ${this.accessory.displayName} (device reports no vent mode support)`,
       );
@@ -254,11 +263,12 @@ export class KumoThermostatAccessory {
       return;
     }
 
+    const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'dry');
     const displayName = this.accessory.context.device.displayName;
     const switchName = `${displayName} Dry`;
 
     this.dryService =
-      this.accessory.getServiceById(this.platform.Service.Switch, 'dry') ||
+      existing ||
       this.accessory.addService(this.platform.Service.Switch, switchName, 'dry');
 
     this.dryService.setCharacteristic(this.platform.Characteristic.Name, switchName);
@@ -274,6 +284,13 @@ export class KumoThermostatAccessory {
       this.isDryActive(this.currentStatus),
     );
 
+    // The profile arrives via an async streaming event, after the accessory
+    // has already been published to the bridge. A service added now is invisible
+    // to HomeKit (and not persisted) unless we re-publish the accessory.
+    if (!existing) {
+      this.platform.api.updatePlatformAccessories([this.accessory]);
+    }
+
     this.platform.log.debug(`Added Dry switch for ${this.accessory.displayName}`);
   }
 
@@ -281,6 +298,7 @@ export class KumoThermostatAccessory {
     const existing = this.accessory.getServiceById(this.platform.Service.Switch, 'dry');
     if (existing) {
       this.accessory.removeService(existing);
+      this.platform.api.updatePlatformAccessories([this.accessory]);
       this.platform.log.debug(
         `Removed Dry switch for ${this.accessory.displayName} (device reports no dry mode support)`,
       );

--- a/test/switch-publish.test.js
+++ b/test/switch-publish.test.js
@@ -110,10 +110,19 @@ function makeHarness() {
     onDeviceProfileUpdate(cb) { profileCb = cb; },
   };
   const accessory = makeAccessory();
-  // eslint-disable-next-line no-new
-  new KumoThermostatAccessory(platform, accessory, kumoAPI, 30);
-  return { accessory, updates, applyProfile: (p) => profileCb(SERIAL, p) };
+  const handler = new KumoThermostatAccessory(platform, accessory, kumoAPI, 30);
+  return { handler, accessory, updates, applyProfile: (p) => profileCb(SERIAL, p) };
 }
+
+const zone = (over = {}) => ({
+  id: 'zone-1',
+  adapter: {
+    deviceSerial: SERIAL, rssi: -50, power: 1, operationMode: 'cool',
+    fanSpeed: null, airDirection: null,
+    roomTemp: 22, spCool: 24, spHeat: 20, spAuto: null, humidity: null,
+    ...over,
+  },
+});
 
 const profile = (over = {}) => ({
   minimumSetPoints: { cool: 16, heat: 10, auto: 16 },
@@ -151,4 +160,22 @@ test('dropping dry support removes the switch and publishes the removal', () => 
   applyProfile(profile({ hasModeDry: false }));
   assert.strictEqual(accessory.getServiceById(Service.Switch, 'dry'), null, 'dry switch removed');
   assert.ok(updates.length > before, 'removal re-published to HomeKit');
+});
+
+// Same bug class as the switches: the humidity characteristic is added to the
+// thermostat service the first time a humidity reading arrives — long after the
+// accessory was published — so it must re-publish too.
+test('first humidity reading publishes the humidity characteristic', () => {
+  const { handler, updates } = makeHarness();
+  const before = updates.length;
+  handler.updateFromZone(zone({ humidity: 51 }));
+  assert.ok(updates.length > before, 'adding humidity characteristic re-published the accessory');
+});
+
+test('humidity characteristic is published only once, not on every reading', () => {
+  const { handler, updates } = makeHarness();
+  handler.updateFromZone(zone({ humidity: 51 }));
+  const after = updates.length;
+  handler.updateFromZone(zone({ humidity: 52 }));
+  assert.strictEqual(updates.length, after, 'no redundant publish once humidity is registered');
 });

--- a/test/switch-publish.test.js
+++ b/test/switch-publish.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+// Regression test for the runtime-switch-publish fix.
+//
+// The fan-only (1.4.0) and dry (1.5.0) switches are added from the async
+// profile_update callback (applyDeviceProfile), AFTER the accessory has already
+// been published to the bridge during discovery. A service added to an
+// already-published accessory is invisible to HomeKit — and never persisted to
+// cachedAccessories — unless the plugin calls
+// api.updatePlatformAccessories([accessory]). It never did, so both switches
+// silently failed to appear in the Home app.
+//
+// These tests drive the compiled accessory with a minimal HAP mock and assert
+// that applying a capability profile both mutates the service set AND
+// re-publishes the accessory. Before the fix, the publish count was 0.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { KumoThermostatAccessory } = require('../dist/accessory.js');
+
+const SERIAL = 'TESTSERIAL001';
+
+function makeLog() {
+  const noop = () => {};
+  return { info: noop, warn: noop, error: noop, debug: noop };
+}
+
+// Stable characteristic identifiers (same object returned per name), with the
+// nested state constants the accessory reads (e.g. CurrentHeatingCoolingState.OFF).
+const charCache = {};
+const Characteristic = new Proxy({}, {
+  get(_t, prop) {
+    if (!charCache[prop]) {
+      charCache[prop] = { _name: String(prop), OFF: 0, HEAT: 1, COOL: 2, AUTO: 3 };
+    }
+    return charCache[prop];
+  },
+});
+
+const Service = {
+  AccessoryInformation: 'AccessoryInformation',
+  Thermostat: 'Thermostat',
+  Switch: 'Switch',
+  FilterMaintenance: 'FilterMaintenance',
+};
+
+function makeCharacteristic() {
+  const ch = {
+    value: undefined,
+    onGet() { return ch; },
+    onSet() { return ch; },
+    setProps() { return ch; },
+  };
+  return ch;
+}
+
+function makeService(type, name, subtype) {
+  const chars = new Map();
+  const svc = {
+    type, name, subtype,
+    getCharacteristic(id) {
+      if (!chars.has(id)) chars.set(id, makeCharacteristic());
+      return chars.get(id);
+    },
+    setCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+    updateCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+  };
+  return svc;
+}
+
+function makeAccessory() {
+  // Pre-seed AccessoryInformation; the constructor uses getService(...)! on it.
+  const entries = [
+    { type: Service.AccessoryInformation, subtype: undefined, svc: makeService(Service.AccessoryInformation) },
+  ];
+  return {
+    displayName: 'Living room',
+    context: { device: { deviceSerial: SERIAL, siteId: 'site-1', displayName: 'Living room' } },
+    getService(type) {
+      const e = entries.find((x) => x.type === type && x.subtype === undefined);
+      return e ? e.svc : null;
+    },
+    getServiceById(type, subtype) {
+      const e = entries.find((x) => x.type === type && x.subtype === subtype);
+      return e ? e.svc : null;
+    },
+    addService(type, name, subtype) {
+      const svc = makeService(type, name, subtype);
+      entries.push({ type, subtype, svc });
+      return svc;
+    },
+    removeService(svc) {
+      const i = entries.findIndex((x) => x.svc === svc);
+      if (i >= 0) entries.splice(i, 1);
+    },
+  };
+}
+
+function makeHarness() {
+  const updates = [];
+  let profileCb = null;
+  const platform = {
+    Service,
+    Characteristic,
+    log: makeLog(),
+    api: { updatePlatformAccessories: (a) => updates.push(a) },
+  };
+  const kumoAPI = {
+    subscribeToDevice() {},
+    onDeviceProfileUpdate(cb) { profileCb = cb; },
+  };
+  const accessory = makeAccessory();
+  // eslint-disable-next-line no-new
+  new KumoThermostatAccessory(platform, accessory, kumoAPI, 30);
+  return { accessory, updates, applyProfile: (p) => profileCb(SERIAL, p) };
+}
+
+const profile = (over = {}) => ({
+  minimumSetPoints: { cool: 16, heat: 10, auto: 16 },
+  maximumSetPoints: { cool: 31, heat: 31, auto: 31 },
+  hasModeVent: true,
+  hasModeDry: true,
+  ...over,
+});
+
+test('applying a vent+dry profile adds both switches and publishes them to HomeKit', () => {
+  const { accessory, updates, applyProfile } = makeHarness();
+  assert.strictEqual(updates.length, 0, 'nothing published before a profile arrives');
+
+  applyProfile(profile());
+
+  assert.ok(accessory.getServiceById(Service.Switch, 'fan-only'), 'fan-only switch added');
+  assert.ok(accessory.getServiceById(Service.Switch, 'dry'), 'dry switch added');
+  // The regression: before the fix this stayed 0 — services existed in memory
+  // but were never pushed to the bridge.
+  assert.ok(updates.length >= 1, 'accessory re-published after adding switches');
+});
+
+test('re-applying the same profile does not re-publish (guarded on real change)', () => {
+  const { updates, applyProfile } = makeHarness();
+  applyProfile(profile());
+  const afterFirst = updates.length;
+  applyProfile(profile());
+  assert.strictEqual(updates.length, afterFirst, 'no redundant HomeKit config bump');
+});
+
+test('dropping dry support removes the switch and publishes the removal', () => {
+  const { accessory, updates, applyProfile } = makeHarness();
+  applyProfile(profile());
+  const before = updates.length;
+  applyProfile(profile({ hasModeDry: false }));
+  assert.strictEqual(accessory.getServiceById(Service.Switch, 'dry'), null, 'dry switch removed');
+  assert.ok(updates.length > before, 'removal re-published to HomeKit');
+});


### PR DESCRIPTION
## Problem
The fan-only switch (since 1.4.0), the dry switch (1.5.0), the humidity characteristic, and the filter indicator were all added to the accessory **after** it was published to the bridge, from async streaming callbacks — but the plugin never called `api.updatePlatformAccessories([accessory])`. They existed in memory and the HAP cache but never reached the Home app.

## Fix
Centralized re-publish in `accessory.ts:publishStructureChange()`, called at every runtime add/remove site (fan/dry switches, humidity characteristic, filter service).

## Verification
- Reproduced and fixed on a live 5-zone bridge (Pi child bridge): HAP cache went from 0 → 10 switch services + humidity characteristics after the fix.
- `test/switch-publish.test.js` extended to cover the humidity path; proven to fail against the pre-fix build (3 publish-asserting tests fail) and pass with it.
- Confirmed end-to-end in the iOS Home app after a controller cache clear.

## Operational note
HomeKit controllers cache the service list and only re-read on a config-number bump; iOS won't show services added to an already-paired accessory until a full device reboot or bridge re-pair. Documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)