### PR TITLE
Don't send a setpoint to a powered-off unit (v1.5.2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       id-token: write # Required for npm Trusted Publishing (OIDC)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # NOTE: do NOT set registry-url / NODE_AUTH_TOKEN here. setup-node writes an
       # .npmrc that expects a token and that interferes with OIDC trusted publishing.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides context about the homebridge-mitsubishi-comfort plugin ar
 
 This is a Homebridge plugin for Mitsubishi heat pumps using the Kumo Cloud v3 API. It provides HomeKit integration for controlling Mitsubishi mini-split systems.
 
-**Current Version:** 1.5.1
+**Current Version:** 1.5.2
 
 ## Architecture Overview
 
@@ -416,6 +416,12 @@ When making changes, verify:
 
 ## Version History
 
+- **1.5.2** - Don't send a setpoint to a powered-off unit (June 2026)
+  - Fixed: setting a TargetTemperature while a unit is off sent a bare `{ spHeat }` with no `operationMode`, which the Kumo v3 API rejects with `modeRequiredWhenDeviceOff` (HTTP 400). Every such attempt logged a cluster of red errors (`Request failed with status: 400` → `Send command failed` → `Failed to set target temperature`)
+  - Real-world trigger: a HomeKit automation/scene that turns the AC off (e.g. "off when the skylight opens") captures each thermostat's *full* state, so firing it re-pushes the last setpoint alongside `off`. The `off` succeeded; the trailing setpoint on the now-off unit produced the 400s. The "all units, same second, `HomeKit sent`" log signature distinguishes a controller-pushed burst from a user tap
+  - Fix: `setTargetTemperature` now short-circuits when `power === 0 || operationMode === 'off'` — it caches the value and echoes it to HomeKit (so the slider holds) without sending a doomed command. Heat/cool/auto paths unchanged
+  - `node:test` regression (`test/setpoint-while-off.test.js`): off → no command sent (failed pre-fix with `1 !== 0`), off → value still echoed, heat → setpoint still sent (control)
+  - Code: `accessory.ts:setTargetTemperature`
 - **1.5.1** - Publish runtime-added features to HomeKit (June 2026)
   - Fixed: the fan-only switch (since 1.4.0), the dry switch (1.5.0), the humidity characteristic, and the filter indicator were all added to the accessory *after* it was published to the bridge (from async `profile_update` / first-reading callbacks) but never re-published — so they existed in memory and the HAP cache but never reached the Home app
   - Root cause: no `api.updatePlatformAccessories([accessory])` call after a runtime structural change. Centralized in `accessory.ts:publishStructureChange()`, called at every add/remove site (switches, humidity, filter)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,7 @@ When making changes, verify:
   - Real-world trigger: a HomeKit automation/scene that turns the AC off (e.g. "off when the skylight opens") captures each thermostat's *full* state, so firing it re-pushes the last setpoint alongside `off`. The `off` succeeded; the trailing setpoint on the now-off unit produced the 400s. The "all units, same second, `HomeKit sent`" log signature distinguishes a controller-pushed burst from a user tap
   - Fix: `setTargetTemperature` now short-circuits when `power === 0 || operationMode === 'off'` — it caches the value and echoes it to HomeKit (so the slider holds) without sending a doomed command. Heat/cool/auto paths unchanged
   - `node:test` regression (`test/setpoint-while-off.test.js`): off → no command sent (failed pre-fix with `1 !== 0`), off → value still echoed, heat → setpoint still sent (control)
+  - CI: bumped `actions/checkout` and `actions/setup-node` to `@v5` in `publish.yml` ahead of the 2026-06-16 Node-20 runner deprecation (no functional change to publishing)
   - Code: `accessory.ts:setTargetTemperature`
 - **1.5.1** - Publish runtime-added features to HomeKit (June 2026)
   - Fixed: the fan-only switch (since 1.4.0), the dry switch (1.5.0), the humidity characteristic, and the filter indicator were all added to the accessory *after* it was published to the bridge (from async `profile_update` / first-reading callbacks) but never re-published — so they existed in memory and the HAP cache but never reached the Home app
@@ -513,7 +514,7 @@ Automated npm publishing on GitHub releases:
 - A Trusted Publisher must be configured for the package on npmjs.com (package → Settings/Access): GitHub org/user `burtherman`, repo `homebridge-mitsubishi-comfort`, workflow `publish.yml`, environment blank
 - `package.json` `repository.url` must match the trusted-publisher repo
 
-**Pending maintenance — runner Node deprecation (flagged June 2026):** the publish run warns that `actions/checkout@v4` and `actions/setup-node@v4` run on Node 20, which GitHub force-migrates to Node 24 on **2026-06-16** (Node 20 removed from runners 2026-09-16). The `@v4` actions are expected to keep working, but bump both to `@v5` in `publish.yml` to remove the risk to the publish pipeline.
+**Runner Node deprecation — resolved in 1.5.2 (2026-06-09):** `actions/checkout` and `actions/setup-node` are pinned to `@v5` (Node 24 runtime), ahead of GitHub's 2026-06-16 force-migration of `@v4` (Node 20) and the 2026-09-16 removal of Node 20 from runners. No further action needed; keep both at `@v5` (or newer) going forward.
 
 **To publish a new version:**
 1. Bump version: `npm version patch/minor/major --no-git-tag-version`, commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Homebridge plugin for Mitsubishi heat pumps using Kumo Cloud v3 API",
   "author": "burtherman",
   "main": "dist/index.js",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -797,6 +797,26 @@ export class KumoThermostatAccessory {
       return;
     }
 
+    // HomeKit can push a target temperature even while the unit is off — its
+    // Thermostat service has no off-aware setpoint, and automations/scenes that
+    // capture a thermostat's full state re-send the last setpoint alongside
+    // `off`. The Kumo v3 API rejects a bare setpoint on a powered-off unit
+    // (`modeRequiredWhenDeviceOff`, HTTP 400), so don't send a doomed command:
+    // the unit is off, there's nothing to set. Cache the value and echo it back
+    // to HomeKit so the slider holds; the setpoint is sent when the unit is
+    // turned on (the mode handlers carry it).
+    if (this.currentStatus.power === 0 || this.currentStatus.operationMode === 'off') {
+      this.platform.log.debug(
+        `[TEMP CHANGE] ${this.accessory.displayName}: unit is off — caching ${temp}°C without sending (API rejects a setpoint while off)`,
+      );
+      this.currentStatus.spHeat = temp;
+      this.service.updateCharacteristic(
+        this.platform.Characteristic.TargetTemperature,
+        temp,
+      );
+      return;
+    }
+
     // Set the appropriate setpoint based on current mode
     const commands: { spHeat?: number; spCool?: number } = {};
 
@@ -809,7 +829,7 @@ export class KumoThermostatAccessory {
       commands.spHeat = temp;
       commands.spCool = temp;
     } else {
-      // If off, set heat setpoint by default
+      // Vent/dry or any other non-off mode: default to the heat setpoint.
       commands.spHeat = temp;
     }
 

--- a/test/setpoint-while-off.test.js
+++ b/test/setpoint-while-off.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+// Regression test for the off-unit setpoint bug.
+//
+// HomeKit's Thermostat service sends TargetTemperature independently of
+// TargetHeatingCoolingState. When an automation (e.g. "turn off the AC when the
+// skylight opens") captures a thermostat's full state, opening the skylight
+// re-pushes each unit's last setpoint alongside `off`. The old code's off branch
+// sent a bare `{ spHeat: temp }` with no operationMode, which the Kumo v3 API
+// rejects with `modeRequiredWhenDeviceOff` (HTTP 400) — producing a cluster of
+// red errors on every skylight-open event even though the unit shut off fine.
+//
+// The unit is off, so there is nothing to set: no command should be sent. The
+// requested value is cached + echoed to HomeKit so the slider doesn't snap back.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { KumoThermostatAccessory } = require('../dist/accessory.js');
+
+const SERIAL = 'TESTSERIAL001';
+
+function makeLog() {
+  const noop = () => {};
+  return { info: noop, warn: noop, error: noop, debug: noop };
+}
+
+const charCache = {};
+const Characteristic = new Proxy({}, {
+  get(_t, prop) {
+    if (!charCache[prop]) {
+      charCache[prop] = { _name: String(prop), OFF: 0, HEAT: 1, COOL: 2, AUTO: 3 };
+    }
+    return charCache[prop];
+  },
+});
+
+const Service = {
+  AccessoryInformation: 'AccessoryInformation',
+  Thermostat: 'Thermostat',
+  Switch: 'Switch',
+  FilterMaintenance: 'FilterMaintenance',
+};
+
+function makeCharacteristic() {
+  const ch = {
+    value: undefined,
+    onGet() { return ch; },
+    onSet() { return ch; },
+    setProps() { return ch; },
+  };
+  return ch;
+}
+
+function makeService(type, name, subtype) {
+  const chars = new Map();
+  const svc = {
+    type, name, subtype,
+    getCharacteristic(id) {
+      if (!chars.has(id)) chars.set(id, makeCharacteristic());
+      return chars.get(id);
+    },
+    setCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+    updateCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+  };
+  return svc;
+}
+
+function makeAccessory() {
+  const entries = [
+    { type: Service.AccessoryInformation, subtype: undefined, svc: makeService(Service.AccessoryInformation) },
+  ];
+  return {
+    displayName: 'Living room',
+    context: { device: { deviceSerial: SERIAL, siteId: 'site-1', displayName: 'Living room' } },
+    getService(type) {
+      const e = entries.find((x) => x.type === type && x.subtype === undefined);
+      return e ? e.svc : null;
+    },
+    getServiceById(type, subtype) {
+      const e = entries.find((x) => x.type === type && x.subtype === subtype);
+      return e ? e.svc : null;
+    },
+    addService(type, name, subtype) {
+      const svc = makeService(type, name, subtype);
+      entries.push({ type, subtype, svc });
+      return svc;
+    },
+    removeService(svc) {
+      const i = entries.findIndex((x) => x.svc === svc);
+      if (i >= 0) entries.splice(i, 1);
+    },
+  };
+}
+
+function makeHarness() {
+  const sendCommandCalls = [];
+  const platform = {
+    Service,
+    Characteristic,
+    log: makeLog(),
+    api: { updatePlatformAccessories() {} },
+  };
+  const kumoAPI = {
+    subscribeToDevice() {},
+    onDeviceProfileUpdate() {},
+    sendCommand(serial, commands) {
+      sendCommandCalls.push({ serial, commands });
+      return Promise.resolve(true);
+    },
+  };
+  const accessory = makeAccessory();
+  const handler = new KumoThermostatAccessory(platform, accessory, kumoAPI, 30);
+  return { handler, accessory, sendCommandCalls };
+}
+
+const zone = (over = {}) => ({
+  id: 'zone-1',
+  adapter: {
+    deviceSerial: SERIAL, rssi: -50, power: 1, operationMode: 'cool',
+    fanSpeed: null, airDirection: null,
+    roomTemp: 22, spCool: 24, spHeat: 20, spAuto: null, humidity: null,
+    ...over,
+  },
+});
+
+test('setting a target temperature while the unit is OFF sends no command', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  // Seed an OFF status the way a streaming/poll update would.
+  handler.updateFromZone(zone({ power: 0, operationMode: 'off', spHeat: 20 }));
+
+  await handler.setTargetTemperature(21);
+
+  // Before the fix this was 1: a bare { spHeat: 21 } that the API rejected with
+  // modeRequiredWhenDeviceOff. The unit is off, so nothing should be sent.
+  assert.strictEqual(sendCommandCalls.length, 0,
+    'no API command should be sent when the unit is off');
+});
+
+test('setting a target temperature while OFF still echoes the value to HomeKit', async () => {
+  const { handler, accessory } = makeHarness();
+  handler.updateFromZone(zone({ power: 0, operationMode: 'off', spHeat: 20 }));
+
+  await handler.setTargetTemperature(21);
+
+  const target = accessory.getService(Service.Thermostat)
+    .getCharacteristic(Characteristic.TargetTemperature);
+  assert.strictEqual(target.value, 21,
+    'HomeKit target temperature still reflects the requested value (slider holds)');
+});
+
+test('setting a target temperature while HEATING still sends the setpoint (control)', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ power: 1, operationMode: 'heat', spHeat: 20 }));
+
+  await handler.setTargetTemperature(22);
+
+  assert.strictEqual(sendCommandCalls.length, 1, 'heat-mode setpoint is sent to the API');
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spHeat: 22 },
+    'sends the heat setpoint with no spurious fields');
+});


### PR DESCRIPTION
## Problem

Setting a `TargetTemperature` while a unit is **off** sent a bare `{ spHeat }` with no `operationMode`. The Kumo v3 API rejects that with `modeRequiredWhenDeviceOff` (HTTP 400), so every attempt logged a cluster of red errors:

```
Request failed with status: 400
  Error response: {"...":{"commands":["modeRequiredWhenDeviceOff"]}}
Send command failed: no response from API for device ...
Failed to set target temperature for <zone>
```

### Real-world trigger

A HomeKit automation/scene that turns the AC off (in this case "turn off the AC when the skylight opens") captures each thermostat's **full** state. When it fires, HomeKit re-pushes each unit's last setpoint *alongside* `off`. The `off` command succeeds and the unit shuts off correctly — but the trailing setpoint on the now-off unit produces the 400s. The giveaway in the logs is all 5 units changing in the same second tagged `HomeKit sent`, which distinguishes a controller-pushed burst from a manual tap.

## Fix

`setTargetTemperature` now short-circuits when `power === 0 || operationMode === 'off'`: it caches the value and echoes it back to HomeKit (so the slider holds) without sending a doomed command. The unit is off — there's nothing to set. Heat / cool / auto paths are unchanged.

## Tests

`test/setpoint-while-off.test.js` (`node:test`):
- **off → no command sent** — failed pre-fix with `1 !== 0`
- **off → value still echoed to HomeKit**
- **heat → setpoint still sent** (control, guards against over-reach)

Full suite: 13/13 passing, `tsc` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)