### PR TITLE
Route the Dry-mode setpoint to spCool (v1.5.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides context about the homebridge-mitsubishi-comfort plugin ar
 
 This is a Homebridge plugin for Mitsubishi heat pumps using the Kumo Cloud v3 API. It provides HomeKit integration for controlling Mitsubishi mini-split systems.
 
-**Current Version:** 1.5.2
+**Current Version:** 1.5.3
 
 ## Architecture Overview
 
@@ -318,7 +318,7 @@ See `API-EXPLORATION-FINDINGS.md` for full field reference including `profile_up
 | HomeKit Characteristic | Kumo API Field | Notes |
 |----------------------|----------------|-------|
 | CurrentTemperature | roomTemp | In Celsius |
-| TargetTemperature | spHeat/spCool | Depends on mode |
+| TargetTemperature | spHeat/spCool | Depends on mode. Dry → `spCool` (Kumo v3 keeps the dry setpoint there; no `spDry` field), gated on `usesSetPointInDryMode` |
 | CurrentHeatingCoolingState | power + operationMode | OFF/HEAT/COOL |
 | TargetHeatingCoolingState | operationMode | OFF/HEAT/COOL/AUTO |
 | CurrentRelativeHumidity | humidity | Optional sensor |
@@ -348,7 +348,7 @@ HomeKit's `Thermostat` service has no dehumidify target state either, so dry is 
 - **Switch OFF** → `sendCommand({ operationMode: 'off', power: 0 })` — turns the unit off entirely
 - The switch is kept in sync with streaming/polling updates: ON iff `power === 1 && operationMode === 'dry'`.
 - **Mutually exclusive with fan-only:** engaging dry optimistically flips the Fan switch off, and engaging fan-only flips the Dry switch off; changing the thermostat to HEAT / COOL / AUTO / OFF flips both off. Streaming/polling reconciles as the authoritative backstop. The optimistic cross-flip is unconditional because a successful command always leaves the unit in this switch's mode or `off` — never the sibling's mode.
-- **Setpoint limitation:** some units report `usesSetPointInDryMode === true`, meaning they accept a target while dehumidifying. An on/off switch can't express that, so dry runs at the unit's default setpoint (same inherent HomeKit constraint as fan having no speed). While dry is active the thermostat tile shows OFF.
+- **Setpoint (since 1.5.3):** units that report `usesSetPointInDryMode === true` accept a target while dehumidifying, and the Kumo v3 cloud keeps that target in **`spCool`** (there is no `spDry` field). The on/off Dry *switch* can't express a temperature, but the **Thermostat's `TargetTemperature` characteristic** now reads/writes `spCool` while in dry (see `getTargetTempFromStatus` / `setTargetTemperature` / `dryUsesSetpoint`). The thermostat tile still shows OFF in dry (`TargetHeatingCoolingState === 0`), so the stock Home app surfaces no dry-setpoint UI — but raw-characteristic clients (e.g. the Portal dashboard) can now read and set it. On units that report `usesSetPointInDryMode === false`, dry stays setpoint-less (the write falls through to the heat branch and the read falls back as before).
 - Code: `accessory.ts:setupDrySwitch / removeDrySwitch / setDryOn / isDryActive`
 
 ## Development Notes
@@ -416,6 +416,13 @@ When making changes, verify:
 
 ## Version History
 
+- **1.5.3** - Route the Dry-mode setpoint to `spCool` (June 2026)
+  - Fixed: in Dry mode the plugin read and wrote the temperature setpoint to `spHeat`, but the Kumo v3 cloud keeps the dry setpoint in `spCool` (there is no `spDry` field). So dry-mode temperature changes silently did nothing — the cloud accepted the `spHeat` write but the unit ignored it, and out-of-range values 400'd with `invalidSpHeatRange`. Reads surfaced the wrong field (e.g. a unit in dry reporting `spCool=25, spHeat=23` showed 23°C)
+  - Live-confirmed (real account, `app-prod.kumocloud.com/v3`): four dry captures held the setpoint in `spCool`; `GET /devices/{serial}/profile` returns `usesSetPointInDryMode: true`; a `POST /devices/send-command {commands:{spCool:24}}` round-trip was adopted and the unit stayed in dry (no flip to cool, no `operationMode` needed)
+  - Fix: explicit `dry` branch in both `setTargetTemperature` (write → `{ spCool }`) and `getTargetTempFromStatus` (read → `spCool`), gated on a new `dryUsesSetpoint()` helper. Surfaced `usesSetPointInDryMode` from the `profile_update` payload (was dropped) into `DeviceProfile`. The gate defaults to "has a setpoint" until the async profile loads, so the common case works immediately; units reporting `usesSetPointInDryMode: false` stay setpoint-less (write falls through to the heat branch, read uses the existing fallback)
+  - HomeKit: corrective + additive. A dry unit reads as `TargetHeatingCoolingState === 0` (OFF) on the Thermostat, so the stock Home app surfaces no dry-setpoint UI; this fixes the value/route for clients that read the raw `TargetTemperature` characteristic. Heat/cool/auto untouched. The 1.5.2 off-guard is unaffected (a dry unit has `power===1, operationMode==='dry'`)
+  - `node:test` regression (`test/dry-setpoint.test.js`): dry write→`{spCool}`, dry write before profile loads→`{spCool}`, gated-false dry→`{spHeat}`, cool/heat controls, dry read→`spCool`, gated-false read→fallback. Proven to fail the 3 core cases against the pre-fix build
+  - Code: `accessory.ts:setTargetTemperature / getTargetTempFromStatus / dryUsesSetpoint`, `settings.ts:DeviceProfile`, `kumo-api.ts:profile_update handler`
 - **1.5.2** - Don't send a setpoint to a powered-off unit (June 2026)
   - Fixed: setting a TargetTemperature while a unit is off sent a bare `{ spHeat }` with no `operationMode`, which the Kumo v3 API rejects with `modeRequiredWhenDeviceOff` (HTTP 400). Every such attempt logged a cluster of red errors (`Request failed with status: 400` → `Send command failed` → `Failed to set target temperature`)
   - Real-world trigger: a HomeKit automation/scene that turns the AC off (e.g. "off when the skylight opens") captures each thermostat's *full* state, so firing it re-pushes the last setpoint alongside `off`. The `off` succeeded; the trailing setpoint on the now-off unit produced the 400s. The "all units, same second, `HomeKit sent`" log signature distinguishes a controller-pushed burst from a user tap

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Homebridge plugin for Mitsubishi heat pumps using Kumo Cloud v3 API",
   "author": "burtherman",
   "main": "dist/index.js",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -650,6 +650,14 @@ export class KumoThermostatAccessory {
       return status.spCool;
     } else if (this.isAutoMode(status.operationMode) && status.spAuto !== null && status.spAuto !== undefined) {
       return status.spAuto;
+    } else if (
+      status.operationMode === 'dry' &&
+      this.dryUsesSetpoint() &&
+      status.spCool !== undefined &&
+      status.spCool !== null
+    ) {
+      // Dry holds its setpoint in spCool, not spHeat (Kumo v3, verified live).
+      return status.spCool;
     }
     // Default to heat setpoint if available, otherwise return a default value
     if (status.spHeat !== undefined && status.spHeat !== null) {
@@ -661,6 +669,20 @@ export class KumoThermostatAccessory {
 
   private isAutoMode(operationMode: string): boolean {
     return operationMode.startsWith('auto');
+  }
+
+  /**
+   * Whether dry mode exposes a settable temperature target on this unit.
+   *
+   * On the Kumo v3 cloud the dry setpoint lives in `spCool` (there is no spDry
+   * field), and the device profile reports `usesSetPointInDryMode`. We treat dry
+   * as having a setpoint unless the profile is loaded and explicitly says it
+   * doesn't — so the common case still works during the brief window before the
+   * async profile_update arrives. Verified live: writing `spCool` while in dry is
+   * adopted and the unit stays in dry.
+   */
+  private dryUsesSetpoint(): boolean {
+    return this.deviceProfile === null || this.deviceProfile.usesSetPointInDryMode;
   }
 
   async getCurrentHeatingCoolingState(): Promise<CharacteristicValue> {
@@ -828,8 +850,14 @@ export class KumoThermostatAccessory {
       // For auto mode, set both setpoints
       commands.spHeat = temp;
       commands.spCool = temp;
+    } else if (this.currentStatus.operationMode === 'dry' && this.dryUsesSetpoint()) {
+      // Dry holds its setpoint in spCool, not spHeat (Kumo v3; there is no spDry
+      // field). Verified live: the spCool write is adopted and the unit stays in
+      // dry — sending spCool alone is sufficient, no operationMode needed.
+      commands.spCool = temp;
     } else {
-      // Vent/dry or any other non-off mode: default to the heat setpoint.
+      // Fan-only ('vent'), dry-without-setpoint, or any other non-off mode:
+      // no meaningful target. Default to the heat setpoint (unchanged behavior).
       commands.spHeat = temp;
     }
 

--- a/src/kumo-api.ts
+++ b/src/kumo-api.ts
@@ -724,6 +724,7 @@ export class KumoAPI {
           numberOfFanSpeeds: data.numberOfFanSpeeds ?? 3,
           hasFanSpeedAuto: data.hasFanSpeedAuto ?? true,
           hasModeDry: data.hasModeDry ?? false,
+          usesSetPointInDryMode: data.usesSetPointInDryMode ?? false,
           hasModeHeat: data.hasModeHeat ?? true,
           hasModeVent: data.hasModeVent ?? false,
           hasVaneDir: data.hasVaneDir ?? false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -90,6 +90,10 @@ export interface DeviceProfile {
   numberOfFanSpeeds: number;
   hasFanSpeedAuto: boolean;
   hasModeDry: boolean;
+  // Dry mode holds its setpoint in spCool on the Kumo v3 cloud (there is no
+  // spDry field). When true, dry has a settable target; when false the unit
+  // dehumidifies at a fixed setpoint and ignores writes. See accessory.ts.
+  usesSetPointInDryMode: boolean;
   hasModeHeat: boolean;
   hasModeVent: boolean;
   hasVaneDir: boolean;

--- a/test/dry-setpoint.test.js
+++ b/test/dry-setpoint.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+// Regression test for the dry-mode setpoint field bug.
+//
+// On the Kumo v3 cloud, Dry mode holds its temperature setpoint in `spCool`
+// (there is no spDry field). The old code routed dry through the catch-all
+// `else` branch that writes/reads `spHeat`, so dry-mode temperature changes
+// silently did nothing — the cloud accepted the spHeat write but the unit
+// ignored it (and some writes 400'd with `invalidSpHeatRange`). Live-confirmed
+// against the real account: a unit in dry reports e.g. spCool=25, spHeat=23, and
+// the plugin surfaced 23 (the wrong field). Writing spCool while in dry is
+// adopted and the unit stays in dry.
+//
+// The fix routes dry to spCool in both setTargetTemperature (write) and
+// getTargetTempFromStatus (read), gated on the device profile's
+// `usesSetPointInDryMode` flag — but defaulting to "has a setpoint" until the
+// async profile arrives, so the common case works immediately.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { KumoThermostatAccessory } = require('../dist/accessory.js');
+
+const SERIAL = 'TESTSERIAL001';
+
+function makeLog() {
+  const noop = () => {};
+  return { info: noop, warn: noop, error: noop, debug: noop };
+}
+
+const charCache = {};
+const Characteristic = new Proxy({}, {
+  get(_t, prop) {
+    if (!charCache[prop]) {
+      charCache[prop] = { _name: String(prop), OFF: 0, HEAT: 1, COOL: 2, AUTO: 3 };
+    }
+    return charCache[prop];
+  },
+});
+
+const Service = {
+  AccessoryInformation: 'AccessoryInformation',
+  Thermostat: 'Thermostat',
+  Switch: 'Switch',
+  FilterMaintenance: 'FilterMaintenance',
+};
+
+function makeCharacteristic() {
+  const ch = {
+    value: undefined,
+    onGet() { return ch; },
+    onSet() { return ch; },
+    setProps() { return ch; },
+  };
+  return ch;
+}
+
+function makeService(type, name, subtype) {
+  const chars = new Map();
+  const svc = {
+    type, name, subtype,
+    getCharacteristic(id) {
+      if (!chars.has(id)) chars.set(id, makeCharacteristic());
+      return chars.get(id);
+    },
+    setCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+    updateCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+  };
+  return svc;
+}
+
+function makeAccessory() {
+  const entries = [
+    { type: Service.AccessoryInformation, subtype: undefined, svc: makeService(Service.AccessoryInformation) },
+  ];
+  return {
+    displayName: 'Kitchen',
+    context: { device: { deviceSerial: SERIAL, siteId: 'site-1', displayName: 'Kitchen' } },
+    getService(type) {
+      const e = entries.find((x) => x.type === type && x.subtype === undefined);
+      return e ? e.svc : null;
+    },
+    getServiceById(type, subtype) {
+      const e = entries.find((x) => x.type === type && x.subtype === subtype);
+      return e ? e.svc : null;
+    },
+    addService(type, name, subtype) {
+      const svc = makeService(type, name, subtype);
+      entries.push({ type, subtype, svc });
+      return svc;
+    },
+    removeService(svc) {
+      const i = entries.findIndex((x) => x.svc === svc);
+      if (i >= 0) entries.splice(i, 1);
+    },
+  };
+}
+
+function makeHarness() {
+  const sendCommandCalls = [];
+  let profileCb = null;
+  const platform = {
+    Service,
+    Characteristic,
+    log: makeLog(),
+    api: { updatePlatformAccessories() {} },
+  };
+  const kumoAPI = {
+    subscribeToDevice() {},
+    onDeviceProfileUpdate(cb) { profileCb = cb; },
+    sendCommand(serial, commands) {
+      sendCommandCalls.push({ serial, commands });
+      return Promise.resolve(true);
+    },
+  };
+  const accessory = makeAccessory();
+  const handler = new KumoThermostatAccessory(platform, accessory, kumoAPI, 30);
+  return { handler, accessory, sendCommandCalls, applyProfile: (p) => profileCb(SERIAL, p) };
+}
+
+const zone = (over = {}) => ({
+  id: 'zone-1',
+  adapter: {
+    deviceSerial: SERIAL, rssi: -50, power: 1, operationMode: 'dry',
+    fanSpeed: null, airDirection: null,
+    roomTemp: 22, spCool: 25, spHeat: 23, spAuto: null, humidity: null,
+    ...over,
+  },
+});
+
+const profile = (over = {}) => ({
+  minimumSetPoints: { cool: 16, heat: 10, auto: 16 },
+  maximumSetPoints: { cool: 31, heat: 31, auto: 31 },
+  hasModeVent: true,
+  hasModeDry: true,
+  usesSetPointInDryMode: true,
+  ...over,
+});
+
+// ---- Write path ----------------------------------------------------------
+
+test('setting a target temperature in DRY sends spCool, not spHeat', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone()); // dry, no profile yet
+
+  await handler.setTargetTemperature(24);
+
+  assert.strictEqual(sendCommandCalls.length, 1, 'a command is sent in dry mode');
+  // Before the fix this was { spHeat: 24 }, which the unit ignored / 400'd.
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spCool: 24 },
+    'dry-mode setpoint is written to spCool (no spHeat, no operationMode)');
+});
+
+test('DRY setpoint routes to spCool even before the device profile arrives', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  // No applyProfile() call — deviceProfile is null, the common startup window.
+  handler.updateFromZone(zone());
+
+  await handler.setTargetTemperature(26);
+
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spCool: 26 },
+    'defaults to a settable dry setpoint until the profile says otherwise');
+});
+
+test('DRY setpoint is suppressed when the profile reports usesSetPointInDryMode=false', async () => {
+  const { handler, sendCommandCalls, applyProfile } = makeHarness();
+  handler.updateFromZone(zone());
+  applyProfile(profile({ usesSetPointInDryMode: false }));
+
+  await handler.setTargetTemperature(24);
+
+  // Such a unit dehumidifies at a fixed setpoint and ignores writes; we fall to
+  // the catch-all (heat) branch rather than writing a spCool it won't honor.
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spHeat: 24 },
+    'fixed-setpoint dry units do not get a spCool write');
+});
+
+test('COOL mode still sends spCool (control — dry branch did not break it)', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ operationMode: 'cool' }));
+
+  await handler.setTargetTemperature(24);
+
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spCool: 24 });
+});
+
+test('HEAT mode still sends spHeat (control)', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ operationMode: 'heat' }));
+
+  await handler.setTargetTemperature(22);
+
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spHeat: 22 });
+});
+
+// ---- Read path -----------------------------------------------------------
+
+test('reading the target temperature in DRY surfaces spCool, not spHeat', async () => {
+  const { handler } = makeHarness();
+  // Live capture: Kitchen in dry reported spCool=25, spHeat=23 (stale).
+  handler.updateFromZone(zone({ spCool: 25, spHeat: 23 }));
+
+  const target = await handler.getTargetTemperature();
+
+  // Before the fix this fell through to the spHeat fallback and returned 23.
+  assert.strictEqual(target, 25, 'dry surfaces the spCool setpoint');
+});
+
+test('DRY read falls back to spHeat when the profile says no dry setpoint', async () => {
+  const { handler, applyProfile } = makeHarness();
+  handler.updateFromZone(zone({ spCool: 25, spHeat: 23 }));
+  applyProfile(profile({ usesSetPointInDryMode: false }));
+
+  const target = await handler.getTargetTemperature();
+
+  assert.strictEqual(target, 23,
+    'a fixed-setpoint dry unit surfaces the existing fallback, not an unrelated spCool');
+});


### PR DESCRIPTION
## Problem

In **Dry** mode the plugin read and wrote the temperature setpoint to **`spHeat`**, but the Kumo v3 cloud keeps the dry setpoint in **`spCool`** (there is no `spDry` field). So dry-mode temperature changes silently did nothing — the cloud accepted the `spHeat` write but the unit ignored it, and out-of-range values 400'd with `invalidSpHeatRange`. Reads surfaced the wrong field: a unit in dry reporting `spCool=25, spHeat=23` showed **23°C**.

## Evidence (live, real account)

- Four dry captures held the setpoint in `spCool`, with `spHeat` stale.
- `GET /devices/{serial}/profile` returns `usesSetPointInDryMode: true` (the plugin was dropping this field).
- Decisive round-trip: `POST /devices/send-command {commands:{spCool:24}}` to a unit in Dry was **adopted** and the unit **stayed in dry** — sending `spCool` alone is sufficient, no `operationMode` needed.

## Fix

- Explicit `dry` branch in **`setTargetTemperature`** (write → `{ spCool }`) and **`getTargetTempFromStatus`** (read → `spCool`).
- New `dryUsesSetpoint()` helper gates on `usesSetPointInDryMode`, surfaced from the `profile_update` payload into `DeviceProfile` (was dropped). The gate **defaults to "has a setpoint"** until the async profile loads, so the common case works immediately; units reporting `usesSetPointInDryMode: false` stay setpoint-less (write falls through to the heat branch, read uses the existing fallback).
- Follows the codebase's established profile-gating pattern (fan switch on `hasModeVent`, dry switch on `hasModeDry`).

## HomeKit safety

Corrective + additive, low risk. A dry unit reads as `TargetHeatingCoolingState === 0` (OFF) on the Thermostat, so the stock Home app surfaces no dry-setpoint UI anyway — this fixes the value/route for clients that read the raw `TargetTemperature` characteristic (e.g. the Portal dashboard). Heat/cool/auto untouched. The 1.5.2 off-guard is unaffected (a dry unit has `power===1, operationMode==='dry'`, so it skips that guard).

## Tests

`test/dry-setpoint.test.js` (7 cases): dry write→`{spCool}`, dry write before the profile loads→`{spCool}`, gated-false dry→`{spHeat}`, cool/heat controls, dry read→`spCool` (the live `spCool=25,spHeat=23` case → surfaces 25), gated-false read→fallback.

**Proven against the pre-fix build:** the 3 core cases fail (controls pass); after the fix all **20** tests pass. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)