### PR TITLE
AUTO-mode dual setpoints (1.6.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides context about the homebridge-mitsubishi-comfort plugin ar
 
 This is a Homebridge plugin for Mitsubishi heat pumps using the Kumo Cloud v3 API. It provides HomeKit integration for controlling Mitsubishi mini-split systems.
 
-**Current Version:** 1.5.3
+**Current Version:** 1.6.0
 
 ## Architecture Overview
 
@@ -319,6 +319,8 @@ See `API-EXPLORATION-FINDINGS.md` for full field reference including `profile_up
 |----------------------|----------------|-------|
 | CurrentTemperature | roomTemp | In Celsius |
 | TargetTemperature | spHeat/spCool | Depends on mode. Dry → `spCool` (Kumo v3 keeps the dry setpoint there; no `spDry` field), gated on `usesSetPointInDryMode` |
+| HeatingThresholdTemperature | spHeat | The low/heat edge of the AUTO band (since 1.6.0). Surfaced by the Home app only in AUTO |
+| CoolingThresholdTemperature | spCool | The high/cool edge of the AUTO band (since 1.6.0). Surfaced by the Home app only in AUTO |
 | CurrentHeatingCoolingState | power + operationMode | OFF/HEAT/COOL |
 | TargetHeatingCoolingState | operationMode | OFF/HEAT/COOL/AUTO |
 | CurrentRelativeHumidity | humidity | Optional sensor |
@@ -326,6 +328,18 @@ See `API-EXPLORATION-FINDINGS.md` for full field reference including `profile_up
 | Model (AccessoryInformation) | modelNumber | Set once from streaming |
 | Switch "Fan" (On) | operationMode === 'vent' && power === 1 | Separate `Switch` service; ON sends `vent`, OFF sends `off` (powers the unit down) |
 | Switch "Dry" (On) | operationMode === 'dry' && power === 1 | Separate `Switch` service; ON sends `dry`, OFF sends `off`. Capability-gated on `hasModeDry`. Mutually exclusive with the Fan switch |
+
+### AUTO dual setpoints
+
+In AUTO, the Home app shows a temperature *range* (two handles) instead of a single setpoint, via the optional `HeatingThresholdTemperature` and `CoolingThresholdTemperature` characteristics on the Thermostat service.
+
+- **Heating handle ↔ `spHeat`** (low/heat edge), **cooling handle ↔ `spCool`** (high/cool edge). These units report `spAuto: null` and `autoModeDisable: false`, so AUTO uses the `spHeat`/`spCool` band — live-verified (every poll showed `Auto: null` with independent setpoints).
+- Both characteristics are added in the constructor (so they publish through the normal discovery path — no `publishStructureChange` needed) and their props are set to the device's supported range in `applyDeviceProfile`.
+- **Writes are independent:** dragging the heating handle sends `{ spHeat }`, the cooling handle sends `{ spCool }` — neither clobbers the other edge. Both inherit the 1.5.2 powered-off guard (cache + echo, no `modeRequiredWhenDeviceOff` 400) and revert on failure.
+- Zone/streaming updates sync both handles. The Home app only surfaces them in AUTO, so refreshing them in HEAT/COOL is harmless even when a unit's stale `spHeat`/`spCool` are inverted (each characteristic is independent within its own min/max props).
+- `TargetTemperature` and the HEAT/COOL/DRY paths are untouched.
+- Code: `accessory.ts:getHeatingThresholdTemperature / getCoolingThresholdTemperature / setThresholdTemperature`
+- Live-verified end-to-end on real hardware (2026-06-14): both handles round-trip to `spHeat`/`spCool`, the cloud holds the band across a streaming reconcile.
 
 ### Fan-only switch
 
@@ -416,6 +430,14 @@ When making changes, verify:
 
 ## Version History
 
+- **1.6.0** - AUTO-mode dual setpoints (June 2026)
+  - In AUTO the Home app now shows a temperature range (two handles) instead of a single collapsed setpoint. Exposes the optional `HeatingThresholdTemperature` (↔ `spHeat`, low/heat edge) and `CoolingThresholdTemperature` (↔ `spCool`, high/cool edge) on the Thermostat service
+  - Before: in AUTO the plugin returned only the single `TargetTemperature`, which fell back to `spHeat` because these units report `spAuto: null` — so the cooling edge of the band was invisible and unsettable
+  - Live-confirmed (real account + Pi): all 5 units report `autoModeDisable: false` (auto IS supported) and `spAuto: null` (so AUTO uses the `spHeat`/`spCool` band, not a single center). End-to-end on Front bedroom via config-ui-x: AUTO engaged, cooling handle → `{spCool}` and heating handle → `{spHeat}` independently (no clobber), cloud held the band across a streaming reconcile
+  - Writes are independent and inherit the 1.5.2 powered-off guard (cache + echo, no `modeRequiredWhenDeviceOff` 400) + revert-on-failure. Zone/streaming updates sync both handles. `TargetTemperature` and the HEAT/COOL/DRY paths are untouched (additive change)
+  - Characteristics added in the constructor so they publish via the normal discovery path; props set from the device profile range in `applyDeviceProfile`
+  - `node:test` regression (`test/auto-setpoint.test.js`, 9 cases): read sync, independent spHeat/spCool writes, the two-handle drag staying two-sided, off-guard, and heat/cool controls proving no regression. 29 tests total green
+  - Code: `accessory.ts:getHeatingThresholdTemperature / getCoolingThresholdTemperature / setThresholdTemperature / applyDeviceProfile / processZoneUpdate`
 - **1.5.3** - Route the Dry-mode setpoint to `spCool` (June 2026)
   - Fixed: in Dry mode the plugin read and wrote the temperature setpoint to `spHeat`, but the Kumo v3 cloud keeps the dry setpoint in `spCool` (there is no `spDry` field). So dry-mode temperature changes silently did nothing — the cloud accepted the `spHeat` write but the unit ignored it, and out-of-range values 400'd with `invalidSpHeatRange`. Reads surfaced the wrong field (e.g. a unit in dry reporting `spCool=25, spHeat=23` showed 23°C)
   - Live-confirmed (real account, `app-prod.kumocloud.com/v3`): four dry captures held the setpoint in `spCool`; `GET /devices/{serial}/profile` returns `usesSetPointInDryMode: true`; a `POST /devices/send-command {commands:{spCool:24}}` round-trip was adopted and the unit stayed in dry (no flip to cool, no `operationMode` needed)

--- a/LOCAL-CONTROL-FEASIBILITY.md
+++ b/LOCAL-CONTROL-FEASIBILITY.md
@@ -1,0 +1,103 @@
+# Local LAN Control — Feasibility Findings
+
+**Date:** 2026-06-14
+**Question:** Can this plugin move from Kumo *Cloud* control to direct *local LAN* control of the indoor units, like the official Home Assistant `mitsubishi_comfort` integration does?
+
+**Bottom line:** Yes, and it's a good fit. The local protocol is fully reverse-engineered in [dlarrick/pykumo](https://github.com/dlarrick/pykumo) and ports to Node's built-in `crypto` in a few lines. Two of the three secrets you need we **already see**: `cryptoSerial` (already fetched from `GET /devices/{serial}/status`, currently unused) and the per-unit local `password` (already arrives in the `adapter_update` Socket.IO event we already subscribe to — and currently strip before logging). The one genuinely new requirement is each unit's **LAN IP**, which the cloud does not hand out.
+
+Recommended shape: **hybrid** — keep cloud login + Socket.IO for discovery and credentials, add a local transport for control + status. This mirrors the official HA integration (`iot_class: local_polling`, "Kumo Cloud only for initial device discovery and credential retrieval").
+
+---
+
+## A. Local protocol (per pykumo source)
+
+### Transport
+- **HTTP PUT** (plain HTTP, no TLS) to `http://<unit-ip>/api?m=<token>`.
+- Headers: `Accept: application/json, text/plain, */*`, `Content-Type: application/json`.
+- Body is the command JSON as UTF-8. **Both reads and writes are PUT** — a status read is a PUT whose body has empty leaf objects; the unit echoes populated values back under `"r"`.
+- Source: `pykumo/py_kumo_base.py` `_request()`.
+
+### Request-signing / security token (per `pykumo/py_kumo_base.py` `_token()` + `pykumo/const.py`)
+
+Constants:
+```
+W_PARAM = hex "44c73283b498d432ff25f5c8e06a016aef931e68f0a00ea710e36e6338fb22db"  (32 bytes)
+S_PARAM = 0
+```
+
+Per-device material: `password` is a **base64** string (decode to bytes); `cryptoSerial` is a **hex** string (decode to bytes).
+
+Algorithm:
+1. `dataHash = SHA256( base64Decode(password) ‖ bodyBytes )`
+2. Build an 88-byte buffer:
+   - `[0..32)`  = `W_PARAM`
+   - `[32..64)` = `dataHash` (all 32 bytes)
+   - `[64..66)` = `0x08 0x40`
+   - `[66]`     = `S_PARAM` (0x00); `[67..79)` stays zero
+   - `[79]`     = `cryptoSerial[8]`
+   - `[80..84)` = `cryptoSerial[4..8)`
+   - `[84..88)` = `cryptoSerial[0..4)`
+3. `token = SHA256(buffer).hex()` → URL `?m=<token>`.
+
+Note the byte-shuffle uses only `cryptoSerial` bytes 0–8, so the decoded `cryptoSerial` must be ≥ 9 bytes (≥ 18 hex chars). Node port is ~15 lines with `crypto.createHash('sha256')`, `Buffer.from(password,'base64')`, `Buffer.from(cryptoSerial,'hex')`, `Buffer.alloc(88)`.
+
+### Command / status JSON (per `pykumo/py_kumo.py`)
+All bodies are `{"c":{"indoorUnit":{"status":{ ... }}}}`:
+
+| Action | Inner `status` object |
+|---|---|
+| Set mode | `{"mode":"<off\|cool\|dry\|heat\|vent\|auto>"}` |
+| Heat setpoint | `{"spHeat":<°C>}` |
+| Cool setpoint | `{"spCool":<°C>}` |
+| Fan speed | `{"fanSpeed":"<superQuiet\|quiet\|low\|powerful\|superPowerful\|auto>"}` |
+| Vane | `{"vaneDir":"<horizontal\|midhorizontal\|midpoint\|midvertical\|vertical\|auto\|swing>"}` |
+| Power | no separate field — `mode:"off"` powers down, any active mode powers on |
+
+Status read sends empty leaves (`{"c":{"indoorUnit":{"status":{}}}}`) and the unit replies under `r.indoorUnit.status` with `mode, standby, spHeat, spCool, roomTemp, fanSpeed, vaneDir, filterDirty, defrost` — i.e. the same data we get today from the cloud `device_update`. Local field names differ: `mode` (not `operationMode`), `vaneDir` (not `airDirection`).
+
+## B. cryptoSerial — is our already-fetched field the local key? **Yes** (per source)
+
+pykumo's v3 cloud module (`py_kumo_cloud_account_v3.py`) reads the crypto key from the **same endpoint we already call** — `GET /v3/devices/{serial}/status` → `status["cryptoSerial"]` — then hex-decodes it and feeds it straight into `_token()`. So the `cryptoSerial` we fetch and currently ignore *is* the local signing key. **Open live check:** confirm our captured value is ≥ 18 hex chars.
+
+## C. Credential + IP retrieval
+
+Three per-unit pieces, three sources:
+1. **`cryptoSerial`** — REST `GET /v3/devices/{serial}/status`. *We already fetch this.*
+2. **Local `password`** — Socket.IO, **not** REST. pykumo v3 forces an `adapter_update` (`force_adapter_request(serial, 'adapterStatus')`) and reads `payload[1].password`. **This is the exact flow we already run** — our CLAUDE.md documents the `force_adapter_request(..., 'adapterStatus')` emit and notes the `adapter_update` payload "contains password, strip before logging." We already receive it and throw it away; capturing it is a one-line change. (Encoding: confirmed base64 on pykumo's v2 path; the v3 websocket-password→base64 assumption is **not 100% verified in source** — resolve with one live capture before trusting it.)
+3. **Local IP** — **the real gap.** No cloud field returns the LAN IP in the code paths read. pykumo gets candidate IPs from HA's DHCP discovery and probes each (authenticated request, match by serial). The official HA integration uses DHCP discovery + optional manual IP. The MAC *is* available (`adapter.macAddress`), but MAC→IP needs on-LAN discovery (mDNS / ARP / DHCP leases) or a user-supplied static IP.
+
+## D. Node port feasibility, risks, effort
+
+**Signing in Node:** unambiguously yes, standard `crypto` primitives, zero new deps. Local PUT is plain `http` to `http://<ip>/api?m=<token>` — client must not force HTTPS.
+
+**Risks / unknowns:**
+1. **IP discovery is the only hard part.** No cloud field gives the LAN IP. v1 should require a user-configured static-IP-per-serial; auto-discovery (mDNS/ARP under a non-root Homebridge service) is a separable, riskier follow-up.
+2. **Same-LAN requirement.** Homebridge host and the units must share a routable subnet; VLAN-segmented IoT networks break this. (Our units and the Pi are on the same LAN today.)
+3. **Adapter reliability / firmware drift.** hass-kumo notes a post-2023 adapter-reliability regression (suspected memory leak, occasional power-cycle needed). Local control surfaces adapter flakes the cloud used to mask — keep degraded-mode polling as the safety net.
+4. **v3 password encoding** — verify base64 with one live capture (see B/C).
+5. Plain HTTP + token-only auth on the LAN; documented design, low concern.
+6. Local `/api` protocol has been stable for years; low churn.
+
+**Effort (hybrid, manual-IP v1):** ~3 focused days — local transport + token port + JSON mapping (~1–1.5d), capture/store local password + wire cryptoSerial (~0.5d), manual static-IP config in `config.schema.json` + per-device local-vs-cloud selection (~0.5d), live verification on the Pi (~0.5–1d). Auto IP discovery: +2–4d, defer.
+
+## E. Recommendation
+
+Pursue it as a **hybrid with manual IP first**. Sequence:
+
+1. **Spike the signing first** (retires the two biggest uncertainties before any refactor): on the Pi, capture one real `adapter_update` (local `password`) + the `cryptoSerial` for one unit, port `_token()` to Node, do one signed `PUT http://<ip>/api?m=<token>` with a status-read body, confirm a `200` + `r.indoorUnit.status`.
+2. **Ship hybrid + manual IP.** Cloud stays the discovery/credential source and fallback transport; local becomes primary control/status when a per-serial IP is configured. Gate per-device, fall back to cloud when local is unreachable.
+3. **Defer auto IP discovery.**
+
+The one real gating constraint is operational, not cryptographic: units and the Homebridge host must share a routable LAN.
+
+---
+
+### Sources
+- [dlarrick/pykumo](https://github.com/dlarrick/pykumo) — `py_kumo_base.py` (`_token`, `_request`), `py_kumo.py` (commands), `const.py` (`W_PARAM`/`S_PARAM`), `py_kumo_cloud_account_v3.py` (v3 cryptoSerial + adapter_update password), `py_kumo_cloud_account.py` (v2 base64/hex), `py_kumo_discovery.py` (IP from upstream DHCP).
+- [Mitsubishi Comfort — Home Assistant](https://www.home-assistant.io/integrations/mitsubishi_comfort/) (hybrid model, `local_polling`, DHCP discovery).
+- [dlarrick/hass-kumo](https://github.com/dlarrick/hass-kumo) (same-LAN requirement, IP-discovery sources, 2023 adapter-reliability caveat).
+
+### Open items to verify live (need one real capture; not yet done)
+- [ ] `cryptoSerial` decoded length ≥ 9 bytes.
+- [ ] v3 `adapter_update.password` is base64 (then a signed local PUT returns 200).
+- [ ] A unit's LAN IP is reachable from the Pi and responds on `/api`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Homebridge plugin for Mitsubishi heat pumps using Kumo Cloud v3 API",
   "author": "burtherman",
   "main": "dist/index.js",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -59,6 +59,26 @@ export class KumoThermostatAccessory {
       .onGet(this.getTargetTemperature.bind(this))
       .onSet(this.setTargetTemperature.bind(this));
 
+    // AUTO-mode dual setpoints. HomeKit's Thermostat surfaces a temperature
+    // *range* (two handles) when TargetHeatingCoolingState === AUTO and these
+    // optional characteristics are present: HeatingThreshold = the low/heat bound
+    // (spHeat), CoolingThreshold = the high/cool bound (spCool). Calling
+    // getCharacteristic adds them to the service; doing it here (during discovery,
+    // before the accessory is (re)published) means they reach HomeKit without a
+    // separate publishStructureChange. Outside AUTO the Home app ignores them and
+    // shows the single TargetTemperature. These units report spAuto: null and use
+    // the spHeat/spCool band for auto — verified against live device data.
+    const wideThresholdProps = { minValue: 10, maxValue: 35, minStep: 0.5 };
+    this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+      .setProps(wideThresholdProps)
+      .onGet(this.getHeatingThresholdTemperature.bind(this))
+      .onSet(this.setHeatingThresholdTemperature.bind(this));
+
+    this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+      .setProps(wideThresholdProps)
+      .onGet(this.getCoolingThresholdTemperature.bind(this))
+      .onSet(this.setCoolingThresholdTemperature.bind(this));
+
     // Note: TemperatureDisplayUnits characteristic is not exposed since the temperature
     // unit preference is account-wide in Kumo Cloud, not per-device
 
@@ -125,6 +145,13 @@ export class KumoThermostatAccessory {
         maxValue: maxTemp,
         minStep: 0.5,
       });
+
+    // Constrain the AUTO band handles to the same supported range so neither the
+    // heating nor cooling threshold can be dragged outside the unit's limits.
+    this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+      .setProps({ minValue: minTemp, maxValue: maxTemp, minStep: 0.5 });
+    this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+      .setProps({ minValue: minTemp, maxValue: maxTemp, minStep: 0.5 });
 
     const minTempF = (minTemp * 9 / 5) + 32;
     const maxTempF = (maxTemp * 9 / 5) + 32;
@@ -567,6 +594,24 @@ export class KumoThermostatAccessory {
         );
       }
 
+      // Keep the AUTO-mode threshold characteristics in sync with the live band.
+      // The Home app only surfaces these in AUTO; refreshing them in any mode is
+      // harmless (each is independent within its own min/max props, so a unit
+      // sitting in heat/cool with an inverted spHeat>spCool pair never trips a
+      // HomeKit constraint — the values just aren't shown until AUTO is selected).
+      if (status.spHeat !== undefined && status.spHeat !== null && !isNaN(status.spHeat)) {
+        this.service.updateCharacteristic(
+          this.platform.Characteristic.HeatingThresholdTemperature,
+          status.spHeat,
+        );
+      }
+      if (status.spCool !== undefined && status.spCool !== null && !isNaN(status.spCool)) {
+        this.service.updateCharacteristic(
+          this.platform.Characteristic.CoolingThresholdTemperature,
+          status.spCool,
+        );
+      }
+
       // Only update humidity if the device has a humidity sensor
       if (this.hasHumiditySensor && status.humidity !== null) {
         this.service.updateCharacteristic(
@@ -887,6 +932,91 @@ export class KumoThermostatAccessory {
       // Note: Platform will update on next poll cycle (no per-device polling timer)
     } else {
       this.platform.log.error(`Failed to set target temperature for ${this.accessory.displayName}: ${JSON.stringify(commands)}`);
+    }
+  }
+
+  // ---- AUTO-mode dual setpoints -------------------------------------------
+  // In AUTO the Home app shows a range; the heating handle reads/writes spHeat
+  // and the cooling handle reads/writes spCool (these units have no spAuto).
+
+  async getHeatingThresholdTemperature(): Promise<CharacteristicValue> {
+    return this.getThresholdTemperature('spHeat', 20);
+  }
+
+  async getCoolingThresholdTemperature(): Promise<CharacteristicValue> {
+    return this.getThresholdTemperature('spCool', 24);
+  }
+
+  private getThresholdTemperature(field: 'spHeat' | 'spCool', fallback: number): number {
+    if (!this.currentStatus) {
+      return fallback;
+    }
+    const v = this.currentStatus[field];
+    if (v === undefined || v === null || isNaN(v)) {
+      return fallback;
+    }
+    return v;
+  }
+
+  async setHeatingThresholdTemperature(value: CharacteristicValue) {
+    await this.setThresholdTemperature('spHeat', value as number);
+  }
+
+  async setCoolingThresholdTemperature(value: CharacteristicValue) {
+    await this.setThresholdTemperature('spCool', value as number);
+  }
+
+  /**
+   * Write one edge of the AUTO setpoint band. HomeKit pushes these when the user
+   * drags the range handles in AUTO: spHeat is the low/heat bound, spCool the
+   * high/cool bound. Mirrors setTargetTemperature — same powered-off guard (the
+   * v3 API 400s a bare setpoint on an off unit, see 1.5.2), optimistic echo, and
+   * revert-on-failure. spHeat/spCool are always the per-mode setpoints, so this
+   * is safe even on the rare out-of-AUTO write.
+   */
+  private async setThresholdTemperature(field: 'spHeat' | 'spCool', temp: number): Promise<void> {
+    const characteristic = field === 'spHeat'
+      ? this.platform.Characteristic.HeatingThresholdTemperature
+      : this.platform.Characteristic.CoolingThresholdTemperature;
+    const label = field === 'spHeat' ? 'AUTO HEAT SP' : 'AUTO COOL SP';
+    const fallback = field === 'spHeat' ? 20 : 24;
+
+    const tempF = (temp * 9 / 5) + 32;
+    this.platform.log.info(
+      `[${label}] ${this.accessory.displayName}: HomeKit sent ${temp.toFixed(1)}°C (${tempF.toFixed(1)}°F)`,
+    );
+
+    if (!this.currentStatus) {
+      this.platform.log.error(`[${label}] ${this.accessory.displayName}: no current status`);
+      return;
+    }
+
+    // Don't send a setpoint to a powered-off unit (1.5.2): cache + echo only so
+    // the handle holds, without a doomed `modeRequiredWhenDeviceOff` 400.
+    if (this.currentStatus.power === 0 || this.currentStatus.operationMode === 'off') {
+      this.platform.log.debug(
+        `[${label}] ${this.accessory.displayName}: unit is off — caching ${temp}°C without sending`,
+      );
+      this.currentStatus[field] = temp;
+      this.service.updateCharacteristic(characteristic, temp);
+      return;
+    }
+
+    const commands: { spHeat?: number; spCool?: number } = {};
+    commands[field] = temp;
+
+    const success = await this.kumoAPI.sendCommand(this.deviceSerial, commands);
+
+    if (success) {
+      this.platform.log.info(`[${label}] ${this.accessory.displayName}: Command accepted by API`);
+      this.currentStatus[field] = temp;
+      this.service.updateCharacteristic(characteristic, temp);
+    } else {
+      this.platform.log.error(`[${label}] ${this.accessory.displayName}: Failed to set ${field} to ${temp}`);
+      // Revert the handle to the actual device state
+      setTimeout(() => {
+        this.service.updateCharacteristic(characteristic, this.getThresholdTemperature(field, fallback));
+      }, 100);
     }
   }
 

--- a/test/auto-setpoint.test.js
+++ b/test/auto-setpoint.test.js
@@ -1,0 +1,236 @@
+'use strict';
+
+// Regression test for AUTO-mode dual setpoints.
+//
+// HomeKit's Thermostat shows a temperature *range* (two handles) in AUTO when
+// the optional HeatingThresholdTemperature / CoolingThresholdTemperature
+// characteristics are present. These units report spAuto: null and keep the auto
+// band in spHeat (low/heat bound) and spCool (high/cool bound) — verified against
+// live device data (every poll showed `Auto: null` with independent spHeat/spCool).
+//
+// Before this change AUTO collapsed to the single TargetTemperature (which, with
+// spAuto null, fell back to spHeat), so the cooling side of the band was invisible
+// and unsettable. Now:
+//   - getHeatingThresholdTemperature -> spHeat,  getCoolingThresholdTemperature -> spCool
+//   - setHeatingThresholdTemperature -> { spHeat }, setCoolingThresholdTemperature -> { spCool }
+//   - zone updates sync both threshold characteristics
+//   - the 1.5.2 powered-off guard applies (no bare setpoint to an off unit)
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { KumoThermostatAccessory } = require('../dist/accessory.js');
+
+const SERIAL = 'TESTSERIAL001';
+
+function makeLog() {
+  const noop = () => {};
+  return { info: noop, warn: noop, error: noop, debug: noop };
+}
+
+const charCache = {};
+const Characteristic = new Proxy({}, {
+  get(_t, prop) {
+    if (!charCache[prop]) {
+      charCache[prop] = { _name: String(prop), OFF: 0, HEAT: 1, COOL: 2, AUTO: 3 };
+    }
+    return charCache[prop];
+  },
+});
+
+const Service = {
+  AccessoryInformation: 'AccessoryInformation',
+  Thermostat: 'Thermostat',
+  Switch: 'Switch',
+  FilterMaintenance: 'FilterMaintenance',
+};
+
+function makeCharacteristic() {
+  const ch = {
+    value: undefined,
+    onGet() { return ch; },
+    onSet() { return ch; },
+    setProps() { return ch; },
+  };
+  return ch;
+}
+
+function makeService(type, name, subtype) {
+  const chars = new Map();
+  const svc = {
+    type, name, subtype,
+    getCharacteristic(id) {
+      if (!chars.has(id)) chars.set(id, makeCharacteristic());
+      return chars.get(id);
+    },
+    setCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+    updateCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+  };
+  return svc;
+}
+
+function makeAccessory() {
+  const entries = [
+    { type: Service.AccessoryInformation, subtype: undefined, svc: makeService(Service.AccessoryInformation) },
+  ];
+  return {
+    displayName: 'Kitchen',
+    context: { device: { deviceSerial: SERIAL, siteId: 'site-1', displayName: 'Kitchen' } },
+    getService(type) {
+      const e = entries.find((x) => x.type === type && x.subtype === undefined);
+      return e ? e.svc : null;
+    },
+    getServiceById(type, subtype) {
+      const e = entries.find((x) => x.type === type && x.subtype === subtype);
+      return e ? e.svc : null;
+    },
+    addService(type, name, subtype) {
+      const svc = makeService(type, name, subtype);
+      entries.push({ type, subtype, svc });
+      return svc;
+    },
+    removeService(svc) {
+      const i = entries.findIndex((x) => x.svc === svc);
+      if (i >= 0) entries.splice(i, 1);
+    },
+  };
+}
+
+function makeHarness() {
+  const sendCommandCalls = [];
+  let profileCb = null;
+  const platform = {
+    Service,
+    Characteristic,
+    log: makeLog(),
+    api: { updatePlatformAccessories() {} },
+  };
+  const kumoAPI = {
+    subscribeToDevice() {},
+    onDeviceProfileUpdate(cb) { profileCb = cb; },
+    sendCommand(serial, commands) {
+      sendCommandCalls.push({ serial, commands });
+      return Promise.resolve(true);
+    },
+  };
+  const accessory = makeAccessory();
+  const handler = new KumoThermostatAccessory(platform, accessory, kumoAPI, 30);
+  return { handler, accessory, sendCommandCalls, applyProfile: (p) => profileCb(SERIAL, p) };
+}
+
+// Read a characteristic value off the Thermostat service.
+function thermostatChar(accessory, charKey) {
+  return accessory.getService(Service.Thermostat).getCharacteristic(Characteristic[charKey]).value;
+}
+
+const zone = (over = {}) => ({
+  id: 'zone-1',
+  adapter: {
+    deviceSerial: SERIAL, rssi: -50, power: 1, operationMode: 'autoCool',
+    fanSpeed: null, airDirection: null,
+    roomTemp: 23, spCool: 26, spHeat: 20, spAuto: null, humidity: null,
+    ...over,
+  },
+});
+
+// ---- Read path -----------------------------------------------------------
+
+test('heating threshold reads spHeat, cooling threshold reads spCool', async () => {
+  const { handler } = makeHarness();
+  handler.updateFromZone(zone({ spHeat: 20, spCool: 26 }));
+
+  assert.strictEqual(await handler.getHeatingThresholdTemperature(), 20);
+  assert.strictEqual(await handler.getCoolingThresholdTemperature(), 26);
+});
+
+test('zone updates sync both AUTO threshold characteristics', async () => {
+  const { handler, accessory } = makeHarness();
+  handler.updateFromZone(zone({ spHeat: 19, spCool: 27 }));
+
+  assert.strictEqual(thermostatChar(accessory, 'HeatingThresholdTemperature'), 19,
+    'spHeat is pushed to the heating handle');
+  assert.strictEqual(thermostatChar(accessory, 'CoolingThresholdTemperature'), 27,
+    'spCool is pushed to the cooling handle');
+});
+
+// ---- Write path ----------------------------------------------------------
+
+test('setting the heating threshold in AUTO sends spHeat only', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone());
+
+  await handler.setHeatingThresholdTemperature(21);
+
+  assert.strictEqual(sendCommandCalls.length, 1);
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spHeat: 21 },
+    'heating handle writes spHeat (no spCool, no operationMode)');
+});
+
+test('setting the cooling threshold in AUTO sends spCool only', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone());
+
+  await handler.setCoolingThresholdTemperature(25);
+
+  assert.strictEqual(sendCommandCalls.length, 1);
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spCool: 25 },
+    'cooling handle writes spCool (no spHeat, no operationMode)');
+});
+
+test('dragging the band sends two independent commands, not a collapsed pair', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ spHeat: 20, spCool: 26 }));
+
+  await handler.setHeatingThresholdTemperature(21);
+  await handler.setCoolingThresholdTemperature(25);
+
+  assert.deepStrictEqual(sendCommandCalls.map((c) => c.commands),
+    [{ spHeat: 21 }, { spCool: 25 }],
+    'the band stays two-sided; neither write clobbers the other edge');
+});
+
+test('an accepted threshold write optimistically updates cached state', async () => {
+  const { handler } = makeHarness();
+  handler.updateFromZone(zone({ spHeat: 20, spCool: 26 }));
+
+  await handler.setCoolingThresholdTemperature(24);
+
+  assert.strictEqual(await handler.getCoolingThresholdTemperature(), 24,
+    'the new spCool is reflected immediately, before the next poll');
+  assert.strictEqual(await handler.getHeatingThresholdTemperature(), 20,
+    'the heating edge is untouched');
+});
+
+// ---- Powered-off guard (inherits the 1.5.2 behavior) ---------------------
+
+test('threshold writes to a powered-off unit are cached, not sent', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ power: 0, operationMode: 'off' }));
+
+  await handler.setHeatingThresholdTemperature(22);
+
+  assert.strictEqual(sendCommandCalls.length, 0,
+    'no bare setpoint is sent to an off unit (would 400 modeRequiredWhenDeviceOff)');
+  assert.strictEqual(await handler.getHeatingThresholdTemperature(), 22,
+    'the value is cached + echoed so the handle holds');
+});
+
+// ---- Controls: single-setpoint modes are unaffected ----------------------
+
+test('HEAT-mode TargetTemperature still sends spHeat (control)', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ operationMode: 'heat' }));
+
+  await handler.setTargetTemperature(22);
+
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spHeat: 22 },
+    'the new threshold characteristics did not disturb the heat path');
+});
+
+test('COOL-mode TargetTemperature still sends spCool (control)', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ operationMode: 'cool' }));
+
+  await handler.setTargetTemperature(23);
+
+  assert.deepStrictEqual(sendCommandCalls[0].commands, { spCool: 23 });
+});


### PR DESCRIPTION
## What

In AUTO, the Home app now shows a temperature **range** (two handles) instead of a single collapsed setpoint. Adds the optional `HeatingThresholdTemperature` (↔ `spHeat`, low/heat edge) and `CoolingThresholdTemperature` (↔ `spCool`, high/cool edge) to the Thermostat service.

## Why

In AUTO the plugin previously returned only the single `TargetTemperature`, which fell back to `spHeat` because these units report `spAuto: null` — so the **cooling edge of the band was invisible and unsettable**.

## How

- Both characteristics added in the constructor (publish via the normal discovery path; no `publishStructureChange` needed); props set from the device profile range in `applyDeviceProfile`.
- Writes are independent — heating handle → `{ spHeat }`, cooling handle → `{ spCool }` — neither clobbers the other edge. Both inherit the 1.5.2 powered-off guard and revert on failure.
- Zone/streaming updates sync both handles. `TargetTemperature` and the HEAT/COOL/DRY paths are untouched (additive).

## Verification

- **Unit:** `test/auto-setpoint.test.js` (9 cases) — read sync, independent writes, two-handle drag staying two-sided, off-guard, heat/cool controls. **29 tests total green.**
- **Live (real account + Pi, 2026-06-14):** all 5 units report `autoModeDisable: false` (auto supported) and `spAuto: null` (band model). End-to-end on Front bedroom via config-ui-x: AUTO engaged, cooling handle → `{spCool}` and heating handle → `{spHeat}` independently, **cloud held the band across a streaming reconcile**, restored to OFF. User confirmed the range renders in the Home app.

Also includes `LOCAL-CONTROL-FEASIBILITY.md` (reference for separate, future local-control work — no code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)