### PR TITLE
Local LAN control + 0.1°C setpoint step (1.7.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides context about the homebridge-mitsubishi-comfort plugin ar
 
 This is a Homebridge plugin for Mitsubishi heat pumps using the Kumo Cloud v3 API. It provides HomeKit integration for controlling Mitsubishi mini-split systems.
 
-**Current Version:** 1.6.0
+**Current Version:** 1.7.0
 
 ## Architecture Overview
 
@@ -288,6 +288,9 @@ See `API-EXPLORATION-FINDINGS.md` for full field reference including `profile_up
 - `streamingStaleThreshold` - Deprecated (no longer used, kept for compatibility)
 - `excludeDevices` - Array of device serials to skip
 - `debug` - Enable debug logging
+- `localControl` - **Opt-in (default false).** Control units directly over the LAN; cloud stays for discovery/credentials and as a per-unit fallback. See "Local LAN Control". Requires a full homebridge restart to toggle (child bridge).
+- `localPollInterval` - Seconds between local status polls when `localControl` is on (default: 15, min: 5, max: 120)
+- `localControlIps` - Optional `{ "<deviceSerial>": "<ip>" }` map to skip LAN discovery for specific units
 
 **Recommended Configuration (Optimal Efficiency):**
 ```json
@@ -365,6 +368,60 @@ HomeKit's `Thermostat` service has no dehumidify target state either, so dry is 
 - **Setpoint (since 1.5.3):** units that report `usesSetPointInDryMode === true` accept a target while dehumidifying, and the Kumo v3 cloud keeps that target in **`spCool`** (there is no `spDry` field). The on/off Dry *switch* can't express a temperature, but the **Thermostat's `TargetTemperature` characteristic** now reads/writes `spCool` while in dry (see `getTargetTempFromStatus` / `setTargetTemperature` / `dryUsesSetpoint`). The thermostat tile still shows OFF in dry (`TargetHeatingCoolingState === 0`), so the stock Home app surfaces no dry-setpoint UI — but raw-characteristic clients (e.g. the Portal dashboard) can now read and set it. On units that report `usesSetPointInDryMode === false`, dry stays setpoint-less (the write falls through to the heat branch and the read falls back as before).
 - Code: `accessory.ts:setupDrySwitch / removeDrySwitch / setDryOn / isDryActive`
 
+## Local LAN Control (since 1.7.0, opt-in)
+
+Direct control of the indoor units over the LAN, modeled on Home Assistant's
+official `mitsubishi_comfort` integration (`iot_class: local_polling`). **Opt-in
+via `localControl: true` (default off).** When off, behavior is unchanged (pure
+cloud). When on, the plugin controls/reads each reachable unit directly and falls
+back to the cloud per-unit; cloud streaming stays connected as the fallback.
+
+**The local protocol** (`src/local-api.ts`) — a port of [pykumo](https://github.com/dlarrick/pykumo),
+byte-for-byte identical to the `mitsubishi-comfort` library behind HA's integration,
+and live-verified against real hardware:
+- `PUT http://<ip>/api?m=<token>` (plain HTTP). Body `{"c":{"indoorUnit":{"status":{...}}}}`.
+  A status read sends empty leaves; the unit echoes values back under `"r"`.
+- `computeLocalToken()`: two SHA-256s over an 88-byte buffer (a fixed `W_PARAM`
+  constant + `sha256(password ‖ body)` + `0x0840` + `S_PARAM=0` + a shuffled slice
+  of the cryptoSerial).
+- Local field names differ: `mode` (not `operationMode`), `vaneDir` (not
+  `airDirection`). **No `power` field — `mode:"off"` is off.** `filterDirty` /
+  `defrost` / `standby` are in the local status; **humidity is not** (it's a separate
+  sensors/MHK2 query, sensor-equipped units only) so it stays cloud-sourced.
+- `LocalKumoClient`: a per-device request mutex (the adapter tolerates ~one
+  concurrent local connection — pykumo locks, the HA lib dropped it, we keep it) and
+  a forgiving `Promise.race` timeout (node-fetch v3 dropped the `timeout` option).
+
+**Credentials** (two per device, both already reachable from the cloud):
+- `password` (base64) — arrives ONLY in the `adapter_update` Socket.IO event we
+  already subscribe to (captured in `kumo-api.ts`, still stripped from logs).
+- `cryptoSerial` (hex, 9 bytes) — `GET /devices/{serial}/status` (`getDeviceCryptoSerial`).
+
+**Discovery** (`discoverDeviceIps`): the cloud provides neither IP nor MAC, so the
+plugin sweeps the host's /24 and matches each device to the adapter that
+authenticates its token (`r.indoorUnit` = match, `_api_error` = other Kumo unit).
+~5–30s for a /24 (verified: found all 5 units). `localControlIps` config skips the
+sweep for listed serials.
+
+**Integration:**
+- `platform.initLocalControl()` runs in the background after streaming connects:
+  waits for passwords, pairs with cryptoSerials, resolves IPs, starts local polling
+  (`localPollInterval`, default 15s). `getHostIpv4()` derives the subnet (prefers
+  private-LAN over CGNAT/VPN like Tailscale).
+- `accessory.sendDeviceCommand()`: local-first, cloud fallback (a failed/unreachable
+  local send falls through to cloud).
+- `accessory.updateFromLocal()`: feeds a local read into `processZoneUpdate` (source
+  `'local'`), preserving streaming-sourced humidity.
+- **Local-authoritative:** while a local poll arrived within 45s, cloud updates are
+  dropped so the cloud's ~7–10s lag can't clobber fresher local data.
+- Code: `src/local-api.ts`, `platform.ts:initLocalControl/getHostIpv4/startLocalPolling`,
+  `accessory.ts:sendDeviceCommand/updateFromLocal`, `kumo-api.ts:onAdapterPassword/getDeviceCryptoSerial`.
+
+**Operational note:** child-bridge accessories get their config from the *parent*
+homebridge process. Toggling `localControl` requires a **full homebridge restart**
+(restart the main process), not just a child-bridge restart — the child reloads code
+but not config.
+
 ## Development Notes
 
 ### Testing Streaming
@@ -430,6 +487,15 @@ When making changes, verify:
 
 ## Version History
 
+- **1.7.0** - Local LAN control + 0.1°C setpoint step (June 2026)
+  - **Opt-in local control** (`localControl: true`, default off): control/read each unit directly over the LAN, falling back to cloud per-unit; cloud streaming stays as the fallback. Modeled on HA's `mitsubishi_comfort` integration. See the "Local LAN Control" section
+  - New `src/local-api.ts`: the pykumo token algorithm (live-verified against real hardware — a signed status read returned 200, and a command was accepted), `LocalKumoClient` (per-device mutex + forgiving timeout), command/status mapping (`mode`/`vaneDir`, no `power`, 0.1 rounding), and LAN discovery (sweep + token-match, since the cloud gives no IP/MAC)
+  - Credentials reuse what we already see: local `password` from the `adapter_update` socket event (was stripped + discarded), `cryptoSerial` from `/devices/{serial}/status` (was fetched + unused)
+  - Local-authoritative status: while a local poll is fresh (≤45s), cloud updates are dropped so the cloud's ~7–10s lag can't clobber it
+  - **0.1°C setpoint step** (`minStep` 0.5→0.1 on TargetTemperature + the AUTO threshold handles): HomeKit is Celsius-native, so 0.5 forced "72°F" to snap to 22.5°C and read back as 73°F in the Kumo app. 0.1 lets 72°F store as ~22.2°C and round-trip faithfully. Live-verified the units honor 0.1°C (the cloud stored a 23.3 setpoint exactly). Applies to the cloud path too
+  - Live-verified end-to-end on the Pi: 5/5 units discovered + controlled locally, polling at 15s, zero errors; the deployed module's read + command both round-tripped against hardware
+  - `node:test`: `test/local-api.test.js` (13 cases) + `test/local-integration.test.js` (6 cases) — token, command builder, status mapping, subnet enumeration, local-first routing, cloud fallback, local-authoritative drop. 48 tests total green
+  - Code: `src/local-api.ts`, `platform.ts`, `accessory.ts`, `kumo-api.ts`, `settings.ts`, `config.schema.json`
 - **1.6.0** - AUTO-mode dual setpoints (June 2026)
   - In AUTO the Home app now shows a temperature range (two handles) instead of a single collapsed setpoint. Exposes the optional `HeatingThresholdTemperature` (↔ `spHeat`, low/heat edge) and `CoolingThresholdTemperature` (↔ `spCool`, high/cool edge) on the Thermostat service
   - Before: in AUTO the plugin returned only the single `TargetTemperature`, which fell back to `spHeat` because these units report `spAuto: null` — so the cooling edge of the band was invisible and unsettable

--- a/config.schema.json
+++ b/config.schema.json
@@ -80,6 +80,25 @@
         "minimum": 5,
         "maximum": 60,
         "description": "Fast polling interval when streaming is unhealthy (default: 10 seconds)"
+      },
+      "localControl": {
+        "title": "Enable Local Control (experimental)",
+        "type": "boolean",
+        "default": false,
+        "description": "Control units directly over the LAN for lower latency and cloud-outage resilience. The cloud is still used for discovery, credentials, and as a per-unit fallback. Your Homebridge host must share a network with the units."
+      },
+      "localPollInterval": {
+        "title": "Local Poll Interval (seconds)",
+        "type": "integer",
+        "default": 15,
+        "minimum": 5,
+        "maximum": 120,
+        "description": "How often to read unit status over the LAN when local control is enabled (default: 15)"
+      },
+      "localControlIps": {
+        "title": "Local IP Overrides",
+        "type": "object",
+        "description": "Optional manual { \"<deviceSerial>\": \"<ip>\" } map to skip LAN discovery for specific units (edit via the JSON config editor)."
       }
     }
   },
@@ -115,6 +134,13 @@
         },
         "debug"
       ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Local Control (experimental)",
+      "expandable": true,
+      "expanded": false,
+      "items": ["localControl", "localPollInterval"]
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Homebridge plugin for Mitsubishi heat pumps using Kumo Cloud v3 API",
   "author": "burtherman",
   "main": "dist/index.js",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -1,7 +1,7 @@
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import { KumoV3Platform } from './platform';
 import { KumoAPI } from './kumo-api';
-import { POLL_INTERVAL, DeviceStatus, DeviceProfile, Zone } from './settings';
+import { POLL_INTERVAL, DeviceStatus, DeviceProfile, Zone, Commands } from './settings';
 
 export class KumoThermostatAccessory {
   private service: Service;
@@ -13,7 +13,12 @@ export class KumoThermostatAccessory {
   private pollIntervalMs: number;
   private hasHumiditySensor: boolean = false;
   private lastUpdateTimestamp: number = 0;
-  private lastUpdateSource: 'streaming' | 'polling' | 'none' = 'none';
+  private lastUpdateSource: 'streaming' | 'polling' | 'local' | 'none' = 'none';
+  private lastLocalUpdateTs: number = 0;
+  // While a local poll has arrived within this window, local is the authoritative
+  // status source and cloud updates are dropped (the cloud lags ~7-10s and would
+  // otherwise clobber fresher local data). Should exceed the local poll interval.
+  private readonly LOCAL_AUTHORITATIVE_MS = 45000;
   private hasReceivedValidUpdate: boolean = false;
   private deviceProfile: DeviceProfile | null = null;
   private filterMaintenanceService: Service | null = null;
@@ -261,7 +266,7 @@ export class KumoThermostatAccessory {
       `[FAN ONLY] ${this.accessory.displayName}: HomeKit sent ${on ? 'ON' : 'OFF'}`,
     );
 
-    const success = await this.kumoAPI.sendCommand(this.deviceSerial, { operationMode, power });
+    const success = await this.sendDeviceCommand({ operationMode, power });
 
     if (!success) {
       this.platform.log.error(
@@ -370,7 +375,7 @@ export class KumoThermostatAccessory {
       `[DRY] ${this.accessory.displayName}: HomeKit sent ${on ? 'ON' : 'OFF'}`,
     );
 
-    const success = await this.kumoAPI.sendCommand(this.deviceSerial, { operationMode, power });
+    const success = await this.sendDeviceCommand({ operationMode, power });
 
     if (!success) {
       this.platform.log.error(
@@ -506,8 +511,93 @@ export class KumoThermostatAccessory {
     const updateTimestamp = Date.now();
     this.processZoneUpdate(zone, 'polling', updateTimestamp);
   }
-  private processZoneUpdate(zone: Zone, source: 'streaming' | 'polling', timestamp: number) {
+
+  /**
+   * Called by the platform's local poller with a locally-read status.
+   * The local API has no humidity (it lives in a separate sensors/MHK2 query),
+   * so we preserve the last humidity from streaming rather than wiping it.
+   */
+  public updateFromLocal(status: Partial<DeviceStatus>) {
+    if (status.roomTemp === undefined || status.roomTemp === null) {
+      return;
+    }
+    const updateTimestamp = Date.now();
+    const zoneUpdate: Partial<Zone> = {
+      id: this.currentStatus?.id || '',
+      adapter: {
+        id: this.currentStatus?.id || '',
+        deviceSerial: this.deviceSerial,
+        roomTemp: status.roomTemp!,
+        spHeat: status.spHeat!,
+        spCool: status.spCool!,
+        spAuto: status.spAuto ?? null,
+        humidity: this.currentStatus?.humidity ?? null, // local has none — keep streaming's
+        power: status.power!,
+        operationMode: status.operationMode!,
+        previousOperationMode: status.operationMode!,
+        fanSpeed: status.fanSpeed || 'auto',
+        airDirection: status.airDirection || 'auto',
+        connected: true,
+        isSimulator: false,
+        hasSensor: this.currentStatus?.humidity !== null && this.currentStatus?.humidity !== undefined,
+        hasMhk2: false,
+        scheduleOwner: 'adapter',
+        scheduleHoldEndTime: 0,
+      },
+    } as Zone;
+
+    this.processZoneUpdate(zoneUpdate as Zone, 'local', updateTimestamp);
+
+    // Filter / defrost / standby come straight from the local status.
+    if (this.currentStatus) {
+      if (status.filterDirty !== undefined) {
+        this.currentStatus.filterDirty = status.filterDirty;
+      }
+      if (status.defrost !== undefined) {
+        this.currentStatus.defrost = status.defrost;
+      }
+      if (status.standby !== undefined) {
+        this.currentStatus.standby = status.standby;
+      }
+      this.updateFilterMaintenance(this.currentStatus.filterDirty ?? false);
+    }
+  }
+
+  /**
+   * Send a control command, preferring the local LAN path when available and
+   * falling back to the cloud. A failed local send (timeout/unreachable) also
+   * falls back, so a flaky adapter never blocks control.
+   */
+  private async sendDeviceCommand(commands: Commands): Promise<boolean> {
+    const local = this.platform.localClient;
+    if (local && local.hasLocal(this.deviceSerial)) {
+      const ok = await local.sendCommand(this.deviceSerial, commands);
+      if (ok) {
+        this.platform.log.debug(`[LOCAL] ${this.accessory.displayName}: command sent locally`);
+        return true;
+      }
+      this.platform.log.debug(
+        `[LOCAL] ${this.accessory.displayName}: local command failed — falling back to cloud`,
+      );
+    }
+    return this.kumoAPI.sendCommand(this.deviceSerial, commands);
+  }
+
+  private processZoneUpdate(zone: Zone, source: 'streaming' | 'polling' | 'local', timestamp: number) {
     try {
+      // When local control is healthy, it is the authoritative status source: drop
+      // cloud (streaming/polling) updates that would clobber fresher local data,
+      // since the cloud lags ~7-10s. Once local goes stale (unreachable), cloud
+      // updates flow again.
+      if (
+        source !== 'local' &&
+        this.lastLocalUpdateTs > 0 &&
+        (Date.now() - this.lastLocalUpdateTs) < this.LOCAL_AUTHORITATIVE_MS
+      ) {
+        this.platform.log.debug(`[${this.deviceSerial}] Ignoring ${source} update — local is authoritative`);
+        return;
+      }
+
       // Prevent old updates from overwriting newer ones
       if (timestamp < this.lastUpdateTimestamp) {
         this.platform.log.debug(
@@ -520,6 +610,9 @@ export class KumoThermostatAccessory {
       this.lastUpdateTimestamp = timestamp;
       const previousSource = this.lastUpdateSource;
       this.lastUpdateSource = source;
+      if (source === 'local') {
+        this.lastLocalUpdateTs = timestamp;
+      }
 
       if (previousSource !== source && previousSource !== 'none') {
         this.platform.log.debug(`[${this.deviceSerial}] Update source changed: ${previousSource} → ${source}`);
@@ -791,7 +884,7 @@ export class KumoThermostatAccessory {
 
     this.platform.log.info(`[MODE CHANGE] ${this.accessory.displayName}: HomeKit sent ${modeName} mode`);
 
-    const success = await this.kumoAPI.sendCommand(this.deviceSerial, {
+    const success = await this.sendDeviceCommand({
       operationMode,
     });
 
@@ -914,7 +1007,7 @@ export class KumoThermostatAccessory {
 
     this.platform.log.info(`[TEMP CHANGE] ${this.accessory.displayName}: Sending to API: ${JSON.stringify(commands)}°C`);
 
-    const success = await this.kumoAPI.sendCommand(this.deviceSerial, commands);
+    const success = await this.sendDeviceCommand(commands);
 
     if (success) {
       this.platform.log.info(`[TEMP CHANGE] ${this.accessory.displayName}: Command accepted by API`);
@@ -1011,7 +1104,7 @@ export class KumoThermostatAccessory {
     const commands: { spHeat?: number; spCool?: number } = {};
     commands[field] = temp;
 
-    const success = await this.kumoAPI.sendCommand(this.deviceSerial, commands);
+    const success = await this.sendDeviceCommand(commands);
 
     if (success) {
       this.platform.log.info(`[${label}] ${this.accessory.displayName}: Command accepted by API`);

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -68,7 +68,13 @@ export class KumoThermostatAccessory {
     // separate publishStructureChange. Outside AUTO the Home app ignores them and
     // shows the single TargetTemperature. These units report spAuto: null and use
     // the spHeat/spCool band for auto — verified against live device data.
-    const wideThresholdProps = { minValue: 10, maxValue: 35, minStep: 0.5 };
+    // minStep 0.1, not 0.5: HomeKit is Celsius-native and the Home app converts
+    // to °F for display. A 0.5°C step forces "72°F" to snap to 22.5°C, which reads
+    // back as 72.5°F → the Kumo app shows 73°F (the long-standing app-vs-HomeKit
+    // mismatch). 0.1°C lets HomeKit store 72°F as ~22.2°C, which round-trips to
+    // 72°F in both apps. Live-verified the units honor 0.1°C (the cloud stored a
+    // 23.3 setpoint exactly, never snapping to 23.5).
+    const wideThresholdProps = { minValue: 10, maxValue: 35, minStep: 0.1 };
     this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .setProps(wideThresholdProps)
       .onGet(this.getHeatingThresholdTemperature.bind(this))
@@ -143,15 +149,15 @@ export class KumoThermostatAccessory {
       .setProps({
         minValue: minTemp,
         maxValue: maxTemp,
-        minStep: 0.5,
+        minStep: 0.1, // 0.1°C for faithful °F round-tripping — see constructor note
       });
 
     // Constrain the AUTO band handles to the same supported range so neither the
     // heating nor cooling threshold can be dragged outside the unit's limits.
     this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
-      .setProps({ minValue: minTemp, maxValue: maxTemp, minStep: 0.5 });
+      .setProps({ minValue: minTemp, maxValue: maxTemp, minStep: 0.1 });
     this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
-      .setProps({ minValue: minTemp, maxValue: maxTemp, minStep: 0.5 });
+      .setProps({ minValue: minTemp, maxValue: maxTemp, minStep: 0.1 });
 
     const minTempF = (minTemp * 9 / 5) + 32;
     const maxTempF = (maxTemp * 9 / 5) + 32;

--- a/src/kumo-api.ts
+++ b/src/kumo-api.ts
@@ -40,6 +40,12 @@ export class KumoAPI {
   private deviceProfileCallbacks: Set<DeviceProfileCallback> = new Set();
   private deviceConnectionCallbacks: Set<DeviceConnectionCallback> = new Set();
 
+  // Local-control credentials: the per-device local password arrives only in the
+  // `adapter_update` Socket.IO event (never via REST). We capture it here for the
+  // local LAN transport (paired with the cryptoSerial from /devices/{serial}/status).
+  private adapterPasswords: Map<string, string> = new Map();
+  private adapterPasswordCallbacks: Set<(serial: string, password: string) => void> = new Set();
+
   // Streaming health tracking
   private streamingHealthCallbacks: Set<(isHealthy: boolean) => void> = new Set();
   private healthCheckTimer: NodeJS.Timeout | null = null;
@@ -685,6 +691,18 @@ export class KumoAPI {
         const serial = data.deviceSerial || 'unknown';
         // Strip password before logging
         const { password, ...safeData } = data;
+        // Capture the local password for the LAN transport (it appears ONLY here,
+        // never in a REST response). Keep stripping it from all log output.
+        if (data.deviceSerial && password) {
+          this.adapterPasswords.set(data.deviceSerial, password);
+          for (const cb of this.adapterPasswordCallbacks) {
+            try {
+              cb(data.deviceSerial, password);
+            } catch (e) {
+              this.log.debug('Adapter password callback error');
+            }
+          }
+        }
         this.log.debug(`Adapter update for ${serial}: fw=${safeData.firmwareVersion}, rssi=${safeData.routerRssi}`);
         if (this.debugMode) {
           this.log.debug(`Adapter update detail: ${JSON.stringify(safeData)}`);
@@ -798,6 +816,31 @@ export class KumoAPI {
   // Profile and connection status callbacks
   onDeviceProfileUpdate(callback: DeviceProfileCallback): void {
     this.deviceProfileCallbacks.add(callback);
+  }
+
+  // ---- Local-control credential accessors ---------------------------------
+
+  /** Notified whenever a device's local password arrives via `adapter_update`. */
+  onAdapterPassword(callback: (serial: string, password: string) => void): void {
+    this.adapterPasswordCallbacks.add(callback);
+  }
+
+  /** The captured local password (base64) for a device, if seen yet. */
+  getAdapterPassword(serial: string): string | undefined {
+    return this.adapterPasswords.get(serial);
+  }
+
+  /** Fetch a device's `cryptoSerial` (hex) — the second half of the local key. */
+  async getDeviceCryptoSerial(serial: string): Promise<string | null> {
+    const status = await this.makeAuthenticatedRequest<{ cryptoSerial?: string }>(
+      `/devices/${serial}/status`,
+    );
+    return status?.cryptoSerial ?? null;
+  }
+
+  /** Ask the cloud to re-push a device's `adapter_update` (carries the password). */
+  requestAdapterStatus(serial: string): void {
+    this.socket?.emit('force_adapter_request', serial, 'adapterStatus');
   }
 
   onDeviceConnectionStatusChange(callback: DeviceConnectionCallback): void {

--- a/src/local-api.ts
+++ b/src/local-api.ts
@@ -241,3 +241,121 @@ export class LocalKumoClient {
     return r !== null;
   }
 }
+
+// ---- LAN discovery --------------------------------------------------------
+// The cloud provides neither the unit's IP nor its MAC, so we find each unit by
+// sweeping the subnet and seeing which adapter authenticates which device's token.
+
+export interface SerialCreds {
+  password: string; // base64
+  cryptoSerial: string; // hex
+}
+
+/** Enumerate the /24 a host IPv4 sits on (x.y.z.1 .. .254), excluding the host itself. */
+export function enumerateSubnet(hostIpv4: string): string[] {
+  const m = hostIpv4.match(/^(\d+\.\d+\.\d+)\.(\d+)$/);
+  if (!m) {
+    return [];
+  }
+  const prefix = m[1];
+  const self = Number(m[2]);
+  const ips: string[] = [];
+  for (let i = 1; i <= 254; i++) {
+    if (i !== self) {
+      ips.push(`${prefix}.${i}`);
+    }
+  }
+  return ips;
+}
+
+type ProbeResult = 'match' | 'kumo' | null;
+
+/**
+ * Probe one IP with one device's token via a status read:
+ *  - 'match' → the adapter authenticated this device (returns r.indoorUnit): IP found
+ *  - 'kumo'  → a Kumo adapter, but a different device (returns _api_error)
+ *  - null    → unreachable / not a Kumo adapter
+ */
+async function probeIpForSerial(ip: string, creds: SerialCreds, timeoutMs: number): Promise<ProbeResult> {
+  try {
+    const token = computeLocalToken(creds.password, creds.cryptoSerial, STATUS_READ_BODY);
+    const fetchPromise = fetch(`http://${ip}/api?m=${token}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'Accept': '*/*' },
+      body: STATUS_READ_BODY,
+    });
+    fetchPromise.catch(() => undefined);
+    const res = await Promise.race([
+      fetchPromise,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs)),
+    ]);
+    if (!res) {
+      return null;
+    }
+    const json = await res.json().catch(() => null) as Record<string, unknown> | null;
+    if (json && json.r && typeof json.r === 'object' && (json.r as Record<string, unknown>).indoorUnit) {
+      return 'match';
+    }
+    if (json && json._api_error) {
+      return 'kumo';
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Run `fn` over `items` with at most `limit` in flight at once. */
+async function mapLimit<T>(items: T[], limit: number, fn: (item: T) => Promise<void>): Promise<void> {
+  let idx = 0;
+  const run = async (): Promise<void> => {
+    while (idx < items.length) {
+      await fn(items[idx++]);
+    }
+  };
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < Math.min(limit, items.length); w++) {
+    workers.push(run());
+  }
+  await Promise.all(workers);
+}
+
+/**
+ * Sweep candidate IPs and return a serial→IP map by matching each device's token
+ * to the adapter that authenticates it. ~5s for a /24 in practice (verified).
+ */
+export async function discoverDeviceIps(
+  log: Logger,
+  candidateIps: string[],
+  creds: Map<string, SerialCreds>,
+  opts: { concurrency?: number; timeoutMs?: number } = {},
+): Promise<Map<string, string>> {
+  const concurrency = opts.concurrency ?? 24;
+  const timeoutMs = opts.timeoutMs ?? 3500;
+  const found = new Map<string, string>();
+  const remaining = new Set(creds.keys());
+
+  await mapLimit(candidateIps, concurrency, async (ip) => {
+    if (remaining.size === 0) {
+      return;
+    }
+    for (const serial of [...remaining]) {
+      const result = await probeIpForSerial(ip, creds.get(serial)!, timeoutMs);
+      if (result === 'match') {
+        found.set(serial, ip);
+        remaining.delete(serial);
+        log.info(`[LOCAL] Discovered ${serial} at ${ip}`);
+        break;
+      }
+      if (result === null) {
+        break; // not a reachable Kumo host — don't bother trying the other serials
+      }
+      // 'kumo': a Kumo adapter that isn't this serial — try the next serial here
+    }
+  });
+
+  if (remaining.size > 0) {
+    log.warn(`[LOCAL] ${remaining.size} device(s) not found on the LAN (will use cloud): ${[...remaining].join(', ')}`);
+  }
+  return found;
+}

--- a/src/local-api.ts
+++ b/src/local-api.ts
@@ -1,0 +1,243 @@
+import { createHash } from 'crypto';
+import fetch from 'node-fetch';
+import { Logger } from 'homebridge';
+import { Commands, DeviceStatus } from './settings';
+
+/**
+ * Local LAN control of Mitsubishi Kumo adapters.
+ *
+ * The indoor-unit WiFi adapter exposes a local HTTP API at
+ * `PUT http://<ip>/api?m=<token>` with a JSON body `{"c":{"indoorUnit":{"status":{...}}}}`.
+ * Both reads and writes are PUTs — a status read sends empty leaf objects and the
+ * unit echoes the populated values back under `"r"`.
+ *
+ * The request is authenticated with a token derived from two per-device secrets:
+ *  - `password`     — base64, from the cloud `adapter_update` Socket.IO event
+ *  - `cryptoSerial` — hex, from the cloud `GET /devices/{serial}/status`
+ *
+ * The token algorithm is a port of dlarrick/pykumo's `_token()` (verified
+ * byte-for-byte against nikolairahimi/mitsubishi-comfort, the library behind
+ * Home Assistant's official `mitsubishi_comfort` integration) and live-confirmed
+ * against real hardware: a signed status read returned `200` + `r.indoorUnit.status`.
+ *
+ * Local-vs-cloud differences worth remembering:
+ *  - Local fields are `mode` (not `operationMode`) and `vaneDir` (not `airDirection`).
+ *  - There is NO `power` field locally — `mode:"off"` powers down, any active mode powers on.
+ *  - `filterDirty` / `defrost` / `standby` come straight from the local status.
+ *  - Humidity is NOT in the status read (it lives in a separate sensors/MHK2 query and
+ *    only exists on sensor-equipped units) — handled by the cloud path for now.
+ */
+
+/** Fixed 32-byte constant baked into the adapter's token scheme (pykumo `W_PARAM`). */
+const W_PARAM = Buffer.from(
+  '44c73283b498d432ff25f5c8e06a016aef931e68f0a00ea710e36e6338fb22db',
+  'hex',
+);
+
+/** The query body for a full status read (empty leaves = "report everything"). */
+export const STATUS_READ_BODY = Buffer.from('{"c":{"indoorUnit":{"status":{}}}}', 'utf8');
+
+export interface LocalDeviceCreds {
+  ip: string;
+  password: string; // base64
+  cryptoSerial: string; // hex, >= 9 bytes
+}
+
+/** Round to 0.1°C — strips float noise; the units honor 0.1 granularity (verified). */
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/**
+ * Compute the URL security token for a given request body.
+ * Port of pykumo `_token()`: two SHA-256s over an 88-byte buffer assembled from
+ * W_PARAM, sha256(password ‖ body), the constant `0x0840`, S_PARAM (0), and a
+ * shuffled slice of the cryptoSerial (bytes [8], [4:8), [0:4)).
+ */
+export function computeLocalToken(passwordB64: string, cryptoSerialHex: string, body: Buffer): string {
+  const password = Buffer.from(passwordB64, 'base64');
+  const cryptoSerial = Buffer.from(cryptoSerialHex, 'hex');
+  if (cryptoSerial.length < 9) {
+    throw new Error(`cryptoSerial too short (${cryptoSerial.length} bytes, need >= 9)`);
+  }
+
+  const dataHash = createHash('sha256').update(Buffer.concat([password, body])).digest();
+
+  const buf = Buffer.alloc(88);
+  W_PARAM.copy(buf, 0); // [0:32)
+  dataHash.copy(buf, 32); // [32:64)
+  buf[64] = 0x08;
+  buf[65] = 0x40; // [64:66)
+  buf[66] = 0x00; // S_PARAM; [67:79) stay zero
+  buf[79] = cryptoSerial[8];
+  cryptoSerial.copy(buf, 80, 4, 8); // [80:84) = cryptoSerial[4:8)
+  cryptoSerial.copy(buf, 84, 0, 4); // [84:88) = cryptoSerial[0:4)
+
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Build the local command body for a set of our cloud-shaped Commands.
+ * Maps `operationMode` → `mode`, rounds setpoints to 0.1°C, and DROPS `power`
+ * (local control expresses on/off purely through `mode`).
+ */
+export function buildLocalCommandBody(commands: Commands): Buffer {
+  const status: Record<string, unknown> = {};
+
+  if (commands.operationMode !== undefined) {
+    status.mode = commands.operationMode; // off/heat/cool/auto/vent/dry — same strings locally
+  }
+  if (commands.spHeat !== undefined) {
+    status.spHeat = round1(commands.spHeat);
+  }
+  if (commands.spCool !== undefined) {
+    status.spCool = round1(commands.spCool);
+  }
+  if (commands.fanSpeed !== undefined) {
+    status.fanSpeed = mapFanSpeedToLocal(commands.fanSpeed);
+  }
+  // Note: commands.power is intentionally ignored — `mode` carries on/off locally.
+
+  return Buffer.from(JSON.stringify({ c: { indoorUnit: { status } } }), 'utf8');
+}
+
+/** Our coarse cloud fan-speed vocabulary → the adapter's local fan-speed strings. */
+function mapFanSpeedToLocal(speed: NonNullable<Commands['fanSpeed']>): string {
+  switch (speed) {
+    case 'auto': return 'auto';
+    case 'low': return 'quiet';
+    case 'medium': return 'low';
+    case 'high': return 'powerful';
+    default: return 'auto';
+  }
+}
+
+/**
+ * Map a local `r.indoorUnit.status` object onto our DeviceStatus shape.
+ * Returns the fields the local API provides; humidity is omitted (cloud-only).
+ */
+export function mapLocalStatus(local: Record<string, unknown>): Partial<DeviceStatus> {
+  const mode = typeof local.mode === 'string' ? local.mode : 'off';
+  return {
+    operationMode: mode,
+    power: mode === 'off' ? 0 : 1,
+    roomTemp: local.roomTemp as number,
+    spHeat: local.spHeat as number,
+    spCool: local.spCool as number,
+    spAuto: null, // these units have no spAuto; auto uses the spHeat/spCool band
+    fanSpeed: (local.fanSpeed as string) ?? 'auto',
+    airDirection: (local.vaneDir as string) ?? 'auto', // local `vaneDir` == cloud `airDirection`
+    filterDirty: local.filterDirty === true,
+    defrost: local.defrost === true,
+    standby: local.standby === true,
+    connected: true, // a successful local read means the unit is reachable
+  };
+}
+
+/**
+ * Per-device local HTTP client. Serializes requests per unit (the adapter
+ * tolerates only ~one concurrent local connection — pykumo locks for this reason;
+ * the HA library dropped the lock, which we don't repeat) and uses a forgiving
+ * timeout (the reference's 1.2s connect timeout flaps on busy WiFi).
+ */
+export class LocalKumoClient {
+  private readonly creds = new Map<string, LocalDeviceCreds>();
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  constructor(
+    private readonly log: Logger,
+    private readonly timeoutMs: number = 6000,
+  ) {}
+
+  setCreds(serial: string, creds: LocalDeviceCreds): void {
+    this.creds.set(serial, creds);
+  }
+
+  clearCreds(serial: string): void {
+    this.creds.delete(serial);
+  }
+
+  hasLocal(serial: string): boolean {
+    return this.creds.has(serial);
+  }
+
+  getIp(serial: string): string | undefined {
+    return this.creds.get(serial)?.ip;
+  }
+
+  /** Run `fn` after any in-flight request for this serial completes (per-device mutex). */
+  private withLock<T>(serial: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.chains.get(serial) ?? Promise.resolve();
+    const next = prev.catch(() => undefined).then(fn);
+    // Swallow errors on the stored chain so one failure doesn't reject the next caller.
+    this.chains.set(serial, next.catch(() => undefined));
+    return next;
+  }
+
+  /**
+   * Send a signed PUT and return the parsed `r` object, or null on any failure
+   * (timeout, network error, auth error, malformed reply). Null means "no data" —
+   * never interpret it as a device state.
+   */
+  async request(serial: string, body: Buffer): Promise<Record<string, unknown> | null> {
+    const creds = this.creds.get(serial);
+    if (!creds) {
+      return null;
+    }
+
+    return this.withLock(serial, async () => {
+      const token = computeLocalToken(creds.password, creds.cryptoSerial, body);
+      try {
+        const fetchPromise = fetch(`http://${creds.ip}/api?m=${token}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/plain, */*',
+          },
+          body,
+        });
+        // node-fetch v3 dropped the `timeout` option, so race the request against a
+        // timer — an unreachable unit must not stall the poll. The losing fetch is
+        // left to settle in the background; swallow its eventual rejection.
+        fetchPromise.catch(() => undefined);
+        const res = await Promise.race([
+          fetchPromise,
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), this.timeoutMs)),
+        ]);
+        if (!res) {
+          this.log.debug(`[LOCAL] ${serial} @ ${creds.ip}: timed out after ${this.timeoutMs}ms`);
+          return null;
+        }
+        const json = await res.json().catch(() => null) as Record<string, unknown> | null;
+        if (json && json.r && typeof json.r === 'object') {
+          return json.r as Record<string, unknown>;
+        }
+        if (json && json._api_error) {
+          this.log.debug(`[LOCAL] ${serial} @ ${creds.ip}: api error ${json._api_error}`);
+        }
+        return null;
+      } catch (err) {
+        this.log.debug(`[LOCAL] ${serial} @ ${creds.ip}: request failed (${(err as Error).message})`);
+        return null;
+      }
+    });
+  }
+
+  /** Read and map the unit's current status locally, or null if unreachable. */
+  async getStatus(serial: string): Promise<Partial<DeviceStatus> | null> {
+    const r = await this.request(serial, STATUS_READ_BODY);
+    const indoorUnit = r?.indoorUnit as Record<string, unknown> | undefined;
+    const status = indoorUnit?.status as Record<string, unknown> | undefined;
+    if (!status || status.roomTemp === undefined) {
+      return null;
+    }
+    return mapLocalStatus(status);
+  }
+
+  /** Send a control command locally. Returns true iff the unit acknowledged with `r`. */
+  async sendCommand(serial: string, commands: Commands): Promise<boolean> {
+    const body = buildLocalCommandBody(commands);
+    const r = await this.request(serial, body);
+    return r !== null;
+  }
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -8,9 +8,12 @@ import {
   Characteristic,
 } from 'homebridge';
 
+import * as os from 'os';
+
 import { PLATFORM_NAME, PLUGIN_NAME, KumoConfig } from './settings';
 import { KumoAPI } from './kumo-api';
 import { KumoThermostatAccessory } from './accessory';
+import { LocalKumoClient, discoverDeviceIps, enumerateSubnet, SerialCreds } from './local-api';
 
 export class KumoV3Platform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service = this.api.hap.Service;
@@ -25,6 +28,11 @@ export class KumoV3Platform implements DynamicPlatformPlugin {
   private readonly degradedPollInterval: number;
   private isStreamingHealthy: boolean = false;
   private isDegradedMode: boolean = false;
+
+  // Local LAN control (opt-in). The client is shared with accessories for
+  // local-first command routing; the platform drives discovery + status polling.
+  public localClient: LocalKumoClient | null = null;
+  private localPollTimer: NodeJS.Timeout | null = null;
 
   // Hysteresis for mode switching - prevents rapid oscillation on flaky connections
   private readonly modeChangeHysteresisMs: number = 10000; // 10 second stability required
@@ -109,6 +117,12 @@ export class KumoV3Platform implements DynamicPlatformPlugin {
     if (this.discoveryRetryTimer) {
       clearTimeout(this.discoveryRetryTimer);
       this.discoveryRetryTimer = null;
+    }
+
+    // Stop local polling
+    if (this.localPollTimer) {
+      clearInterval(this.localPollTimer);
+      this.localPollTimer = null;
     }
 
     // Clean up all site pollers
@@ -331,6 +345,15 @@ export class KumoV3Platform implements DynamicPlatformPlugin {
             this.log.info('Strategy: Streaming primary, polling supplemental');
           }
         }
+
+        // Local LAN control (opt-in). Set up in the background: it waits for the
+        // adapter passwords (which arrive via adapter_update after streaming
+        // connects), then discovers each unit's IP. Never blocks startup, and
+        // cloud streaming stays up as the per-unit fallback.
+        if (this.kumoConfig.localControl) {
+          this.initLocalControl(allDeviceSerials).catch(err =>
+            this.log.error('Local control setup failed:', err));
+        }
       }
 
       // Start site-level polling based on configuration and streaming health
@@ -353,6 +376,141 @@ export class KumoV3Platform implements DynamicPlatformPlugin {
       this.log.error('Error during device discovery:', error);
       return false;
     }
+  }
+
+  /**
+   * Set up local LAN control: wait for the per-device credentials, resolve each
+   * unit's IP (manual override or LAN sweep), and start local status polling.
+   * Best-effort and per-device — any unit we can't reach locally simply stays on
+   * the cloud path. Runs in the background; never blocks discovery.
+   */
+  private async initLocalControl(serials: string[]): Promise<void> {
+    this.log.info('Local control enabled — gathering credentials...');
+    this.localClient = new LocalKumoClient(this.log);
+
+    // The local password arrives via adapter_update shortly after streaming
+    // connects. Nudge each device and poll for up to ~25s for both halves of the
+    // key (password from the socket, cryptoSerial from REST).
+    for (const serial of serials) {
+      this.kumoAPI.requestAdapterStatus(serial);
+    }
+    const creds = new Map<string, SerialCreds>();
+    const deadline = Date.now() + 25000;
+    while (Date.now() < deadline && creds.size < serials.length) {
+      for (const serial of serials) {
+        if (creds.has(serial)) {
+          continue;
+        }
+        const password = this.kumoAPI.getAdapterPassword(serial);
+        if (!password) {
+          continue;
+        }
+        const cryptoSerial = await this.kumoAPI.getDeviceCryptoSerial(serial);
+        if (cryptoSerial) {
+          creds.set(serial, { password, cryptoSerial });
+        }
+      }
+      if (creds.size < serials.length) {
+        await new Promise(resolve => setTimeout(resolve, 2000));
+        for (const serial of serials) {
+          if (!creds.has(serial)) {
+            this.kumoAPI.requestAdapterStatus(serial);
+          }
+        }
+      }
+    }
+
+    if (creds.size === 0) {
+      this.log.warn('Local control: no credentials obtained — staying on cloud');
+      this.localClient = null;
+      return;
+    }
+    this.log.info(`Local control: credentials for ${creds.size}/${serials.length} device(s)`);
+
+    // Resolve IPs — configured overrides first, then sweep the LAN for the rest.
+    const manual = this.kumoConfig.localControlIps || {};
+    const toDiscover = new Map<string, SerialCreds>();
+    for (const [serial, c] of creds) {
+      if (manual[serial]) {
+        this.localClient.setCreds(serial, { ...c, ip: manual[serial] });
+        this.log.info(`Local control: ${serial} -> ${manual[serial]} (configured)`);
+      } else {
+        toDiscover.set(serial, c);
+      }
+    }
+    if (toDiscover.size > 0) {
+      const hostIp = this.getHostIpv4();
+      if (!hostIp) {
+        this.log.warn('Local control: could not determine the host LAN subnet for discovery');
+      } else {
+        const candidates = enumerateSubnet(hostIp);
+        this.log.info(`Local control: sweeping ${candidates.length} addresses on ${hostIp}'s subnet...`);
+        const ips = await discoverDeviceIps(this.log, candidates, toDiscover);
+        for (const [serial, ip] of ips) {
+          this.localClient.setCreds(serial, { ...toDiscover.get(serial)!, ip });
+        }
+      }
+    }
+
+    const localCount = serials.filter(serial => this.localClient!.hasLocal(serial)).length;
+    if (localCount === 0) {
+      this.log.warn('Local control: no devices reachable on the LAN — staying on cloud');
+      return;
+    }
+    this.log.info(`✓ Local control active for ${localCount}/${serials.length} device(s)`);
+    this.startLocalPolling();
+  }
+
+  /** Find the host's primary private-LAN IPv4 (to derive the sweep subnet). */
+  private getHostIpv4(): string | null {
+    const ifaces = os.networkInterfaces();
+    let fallback: string | null = null;
+    for (const name of Object.keys(ifaces)) {
+      for (const ni of ifaces[name] || []) {
+        if (ni.family !== 'IPv4' || ni.internal || ni.address.startsWith('169.254.')) {
+          continue;
+        }
+        // Prefer a private-LAN address (10/8, 192.168/16, 172.16/12) over e.g. a
+        // CGNAT/VPN range like Tailscale's 100.64/10.
+        if (/^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/.test(ni.address)) {
+          return ni.address;
+        }
+        fallback = fallback || ni.address;
+      }
+    }
+    return fallback;
+  }
+
+  /** Poll the locally-reachable units and feed their status into the accessories. */
+  private startLocalPolling(): void {
+    if (this.localPollTimer) {
+      return;
+    }
+    const interval = (this.kumoConfig.localPollInterval || 15) * 1000;
+    this.log.info(`Local status polling every ${interval / 1000}s`);
+
+    const poll = async () => {
+      if (!this.localClient) {
+        return;
+      }
+      for (const handler of this.accessoryHandlers) {
+        const serial = handler.getDeviceSerial();
+        if (!this.localClient.hasLocal(serial)) {
+          continue;
+        }
+        try {
+          const status = await this.localClient.getStatus(serial);
+          if (status) {
+            handler.updateFromLocal(status);
+          }
+        } catch (error) {
+          this.log.debug(`Local poll error for ${serial}: ${(error as Error).message}`);
+        }
+      }
+    };
+
+    poll();
+    this.localPollTimer = setInterval(poll, interval);
   }
 
   private startSitePoller(siteId: string) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,14 @@ export interface KumoConfig {
   streamingHealthCheckInterval?: number;
   streamingStaleThreshold?: number;
   degradedPollInterval?: number;
+  // Local LAN control (opt-in). When true, the plugin discovers each unit's IP on
+  // the LAN and controls/reads it directly, falling back to cloud per-unit when a
+  // unit is unreachable. Cloud streaming stays connected as the fallback.
+  localControl?: boolean;
+  // Optional manual serial -> IP overrides (skip discovery for these units).
+  localControlIps?: Record<string, string>;
+  // Seconds between local status polls (default 15).
+  localPollInterval?: number;
 }
 
 export interface LoginResponse {

--- a/test/local-api.test.js
+++ b/test/local-api.test.js
@@ -13,6 +13,7 @@ const {
   computeLocalToken,
   buildLocalCommandBody,
   mapLocalStatus,
+  enumerateSubnet,
   STATUS_READ_BODY,
 } = require('../dist/local-api.js');
 
@@ -106,4 +107,18 @@ test('boolean status flags default to false when absent', () => {
   assert.strictEqual(mapped.filterDirty, false);
   assert.strictEqual(mapped.defrost, false);
   assert.strictEqual(mapped.standby, false);
+});
+
+// ---- enumerateSubnet ------------------------------------------------------
+
+test('enumerateSubnet returns the /24 minus the host', () => {
+  const ips = enumerateSubnet('192.168.50.244');
+  assert.strictEqual(ips.length, 253, '254 hosts minus self');
+  assert.ok(!ips.includes('192.168.50.244'), 'excludes the host itself');
+  assert.ok(ips.includes('192.168.50.1') && ips.includes('192.168.50.254'), 'spans .1...254');
+  assert.ok(ips.every((ip) => ip.startsWith('192.168.50.')), 'all in the same /24');
+});
+
+test('enumerateSubnet returns [] for a non-IPv4 string', () => {
+  assert.deepStrictEqual(enumerateSubnet('not-an-ip'), []);
 });

--- a/test/local-api.test.js
+++ b/test/local-api.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// Unit tests for the local LAN transport core (src/local-api.ts).
+//
+// The token algorithm is a port of pykumo's `_token()`, already live-verified
+// against real hardware (a signed status read returned 200 + r.indoorUnit.status).
+// These tests guard the PORT against regressions — determinism, shape, and
+// sensitivity to inputs — plus the pure command/status mapping logic.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  computeLocalToken,
+  buildLocalCommandBody,
+  mapLocalStatus,
+  STATUS_READ_BODY,
+} = require('../dist/local-api.js');
+
+// 10-byte hex cryptoSerial (>= 9 bytes) + base64 password.
+const CS = '0123456789abcdef0123';
+const PW = Buffer.from('local-secret').toString('base64');
+
+// ---- computeLocalToken ----------------------------------------------------
+
+test('token is a deterministic 64-char hex string', () => {
+  const a = computeLocalToken(PW, CS, STATUS_READ_BODY);
+  const b = computeLocalToken(PW, CS, STATUS_READ_BODY);
+  assert.strictEqual(a, b, 'same inputs -> same token');
+  assert.match(a, /^[0-9a-f]{64}$/, 'sha-256 hex digest');
+});
+
+test('token changes with the request body', () => {
+  const read = computeLocalToken(PW, CS, STATUS_READ_BODY);
+  const write = computeLocalToken(PW, CS, buildLocalCommandBody({ spCool: 23 }));
+  assert.notStrictEqual(read, write);
+});
+
+test('token changes with the credentials', () => {
+  const t1 = computeLocalToken(PW, CS, STATUS_READ_BODY);
+  const t2 = computeLocalToken(PW, 'fedcba98765432100123', STATUS_READ_BODY);
+  const t3 = computeLocalToken(Buffer.from('other').toString('base64'), CS, STATUS_READ_BODY);
+  assert.notStrictEqual(t1, t2, 'cryptoSerial affects the token');
+  assert.notStrictEqual(t1, t3, 'password affects the token');
+});
+
+test('token rejects a too-short cryptoSerial (< 9 bytes)', () => {
+  assert.throws(() => computeLocalToken(PW, '0123456789abcdef', STATUS_READ_BODY), /too short/);
+});
+
+// ---- buildLocalCommandBody ------------------------------------------------
+
+const parseBody = (buf) => JSON.parse(buf.toString('utf8'));
+const innerStatus = (cmds) => parseBody(buildLocalCommandBody(cmds)).c.indoorUnit.status;
+
+test('operationMode maps to the local `mode` field', () => {
+  assert.deepStrictEqual(innerStatus({ operationMode: 'cool' }), { mode: 'cool' });
+  assert.deepStrictEqual(innerStatus({ operationMode: 'auto' }), { mode: 'auto' });
+});
+
+test('power is dropped — on/off is expressed by mode only', () => {
+  // The cloud fan/dry/off paths send an explicit power; locally there is no
+  // power field, so it must never appear in the body.
+  assert.deepStrictEqual(innerStatus({ operationMode: 'off', power: 0 }), { mode: 'off' });
+  assert.deepStrictEqual(innerStatus({ operationMode: 'vent', power: 1 }), { mode: 'vent' });
+});
+
+test('setpoints are sent under spHeat/spCool, rounded to 0.1°C', () => {
+  assert.deepStrictEqual(innerStatus({ spCool: 23.34 }), { spCool: 23.3 });
+  assert.deepStrictEqual(innerStatus({ spHeat: 21.06 }), { spHeat: 21.1 });
+  assert.deepStrictEqual(innerStatus({ spHeat: 20, spCool: 24 }), { spHeat: 20, spCool: 24 });
+});
+
+test('the command envelope is {"c":{"indoorUnit":{"status":{...}}}}', () => {
+  const body = parseBody(buildLocalCommandBody({ spCool: 23 }));
+  assert.deepStrictEqual(Object.keys(body), ['c']);
+  assert.deepStrictEqual(Object.keys(body.c), ['indoorUnit']);
+  assert.deepStrictEqual(Object.keys(body.c.indoorUnit), ['status']);
+});
+
+// ---- mapLocalStatus -------------------------------------------------------
+
+test('local status maps onto DeviceStatus (mode->operationMode, vaneDir->airDirection)', () => {
+  const mapped = mapLocalStatus({
+    mode: 'cool', roomTemp: 27, spCool: 24.5, spHeat: 22.5,
+    vaneDir: 'swing', fanSpeed: 'auto', filterDirty: true, defrost: false, standby: false,
+  });
+  assert.strictEqual(mapped.operationMode, 'cool');
+  assert.strictEqual(mapped.power, 1, 'a non-off mode is powered on');
+  assert.strictEqual(mapped.roomTemp, 27);
+  assert.strictEqual(mapped.spCool, 24.5);
+  assert.strictEqual(mapped.spHeat, 22.5);
+  assert.strictEqual(mapped.airDirection, 'swing', 'vaneDir maps to airDirection');
+  assert.strictEqual(mapped.filterDirty, true);
+  assert.strictEqual(mapped.spAuto, null, 'these units have no spAuto');
+  assert.strictEqual(mapped.connected, true, 'a successful read means reachable');
+});
+
+test('mode "off" maps to power 0', () => {
+  const mapped = mapLocalStatus({ mode: 'off', roomTemp: 22, spCool: 24, spHeat: 20 });
+  assert.strictEqual(mapped.power, 0);
+  assert.strictEqual(mapped.operationMode, 'off');
+});
+
+test('boolean status flags default to false when absent', () => {
+  const mapped = mapLocalStatus({ mode: 'heat', roomTemp: 21, spHeat: 21, spCool: 24 });
+  assert.strictEqual(mapped.filterDirty, false);
+  assert.strictEqual(mapped.defrost, false);
+  assert.strictEqual(mapped.standby, false);
+});

--- a/test/local-integration.test.js
+++ b/test/local-integration.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// Integration tests for local control wiring in the accessory:
+//  - updateFromLocal() feeds a locally-read status into the characteristics
+//  - local is authoritative: a cloud (polling/streaming) update is dropped while a
+//    recent local poll exists (the cloud lags ~7-10s and would clobber it)
+//  - sendDeviceCommand() prefers local and falls back to cloud on local failure
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { KumoThermostatAccessory } = require('../dist/accessory.js');
+
+const SERIAL = 'TESTSERIAL001';
+
+function makeLog() {
+  const noop = () => {};
+  return { info: noop, warn: noop, error: noop, debug: noop };
+}
+
+const charCache = {};
+const Characteristic = new Proxy({}, {
+  get(_t, prop) {
+    if (!charCache[prop]) {
+      charCache[prop] = { _name: String(prop), OFF: 0, HEAT: 1, COOL: 2, AUTO: 3 };
+    }
+    return charCache[prop];
+  },
+});
+
+const Service = {
+  AccessoryInformation: 'AccessoryInformation',
+  Thermostat: 'Thermostat',
+  Switch: 'Switch',
+  FilterMaintenance: 'FilterMaintenance',
+};
+
+function makeCharacteristic() {
+  const ch = { value: undefined, onGet() { return ch; }, onSet() { return ch; }, setProps() { return ch; } };
+  return ch;
+}
+
+function makeService(type, name, subtype) {
+  const chars = new Map();
+  const svc = {
+    type, name, subtype,
+    getCharacteristic(id) { if (!chars.has(id)) chars.set(id, makeCharacteristic()); return chars.get(id); },
+    setCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+    updateCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+  };
+  return svc;
+}
+
+function makeAccessory() {
+  const entries = [{ type: Service.AccessoryInformation, subtype: undefined, svc: makeService(Service.AccessoryInformation) }];
+  return {
+    displayName: 'Kitchen',
+    context: { device: { deviceSerial: SERIAL, siteId: 'site-1', displayName: 'Kitchen' } },
+    getService(type) { const e = entries.find((x) => x.type === type && x.subtype === undefined); return e ? e.svc : null; },
+    getServiceById(type, subtype) { const e = entries.find((x) => x.type === type && x.subtype === subtype); return e ? e.svc : null; },
+    addService(type, name, subtype) { const svc = makeService(type, name, subtype); entries.push({ type, subtype, svc }); return svc; },
+    removeService(svc) { const i = entries.findIndex((x) => x.svc === svc); if (i >= 0) entries.splice(i, 1); },
+  };
+}
+
+function makeLocalClient(over = {}) {
+  const calls = [];
+  return {
+    calls,
+    hasLocalResult: true,
+    sendCommandResult: true,
+    hasLocal() { return this.hasLocalResult; },
+    sendCommand(serial, commands) { calls.push({ serial, commands }); return Promise.resolve(this.sendCommandResult); },
+    getStatus() { return Promise.resolve(null); },
+    ...over,
+  };
+}
+
+function makeHarness({ localClient = null } = {}) {
+  const sendCommandCalls = [];
+  const platform = {
+    Service,
+    Characteristic,
+    log: makeLog(),
+    api: { updatePlatformAccessories() {} },
+    localClient,
+  };
+  const kumoAPI = {
+    subscribeToDevice() {},
+    onDeviceProfileUpdate() {},
+    sendCommand(serial, commands) { sendCommandCalls.push({ serial, commands }); return Promise.resolve(true); },
+  };
+  const handler = new KumoThermostatAccessory(platform, makeAccessory(), kumoAPI, 30);
+  return { handler, sendCommandCalls, platform };
+}
+
+const localStatus = (over = {}) => ({
+  roomTemp: 24, operationMode: 'cool', power: 1, spCool: 23, spHeat: 20,
+  spAuto: null, fanSpeed: 'auto', airDirection: 'auto', filterDirty: false,
+  defrost: false, standby: false, ...over,
+});
+
+const cloudZone = (over = {}) => ({
+  id: 'zone-1',
+  adapter: {
+    deviceSerial: SERIAL, rssi: -50, power: 1, operationMode: 'cool',
+    fanSpeed: 'auto', airDirection: 'auto',
+    roomTemp: 30, spCool: 28, spHeat: 20, spAuto: null, humidity: null, ...over,
+  },
+});
+
+// ---- updateFromLocal ------------------------------------------------------
+
+test('updateFromLocal feeds a locally-read status into the characteristics', async () => {
+  const { handler } = makeHarness();
+  handler.updateFromLocal(localStatus({ roomTemp: 24, operationMode: 'cool', spCool: 23 }));
+
+  assert.strictEqual(await handler.getCurrentTemperature(), 24);
+  assert.strictEqual(await handler.getTargetTemperature(), 23, 'cool mode surfaces spCool');
+});
+
+// ---- local authoritative --------------------------------------------------
+
+test('a cloud update is dropped while a recent local poll exists', async () => {
+  const { handler } = makeHarness();
+  handler.updateFromLocal(localStatus({ roomTemp: 24 }));
+  // Cloud streaming/polling lags and reports a stale 30°C — must NOT clobber local.
+  handler.updateFromZone(cloudZone({ roomTemp: 30 }));
+
+  assert.strictEqual(await handler.getCurrentTemperature(), 24, 'local stays authoritative');
+});
+
+test('cloud updates still apply when no local data exists', async () => {
+  const { handler } = makeHarness();
+  handler.updateFromZone(cloudZone({ roomTemp: 30 }));
+  assert.strictEqual(await handler.getCurrentTemperature(), 30, 'pure-cloud path unaffected');
+});
+
+// ---- sendDeviceCommand routing --------------------------------------------
+
+test('commands prefer the local path when a unit is locally reachable', async () => {
+  const local = makeLocalClient();
+  const { handler, sendCommandCalls } = makeHarness({ localClient: local });
+  handler.updateFromLocal(localStatus({ operationMode: 'heat', spHeat: 20 }));
+
+  await handler.setTargetTemperature(22);
+
+  assert.deepStrictEqual(local.calls.map((c) => c.commands), [{ spHeat: 22 }], 'sent locally');
+  assert.strictEqual(sendCommandCalls.length, 0, 'cloud not used');
+});
+
+test('a failed local command falls back to the cloud', async () => {
+  const local = makeLocalClient({ sendCommandResult: false });
+  const { handler, sendCommandCalls } = makeHarness({ localClient: local });
+  handler.updateFromLocal(localStatus({ operationMode: 'heat', spHeat: 20 }));
+
+  await handler.setTargetTemperature(22);
+
+  assert.strictEqual(local.calls.length, 1, 'local attempted first');
+  assert.deepStrictEqual(sendCommandCalls.map((c) => c.commands), [{ spHeat: 22 }], 'then cloud');
+});
+
+test('commands skip local when the unit is not locally reachable', async () => {
+  const local = makeLocalClient({ hasLocalResult: false });
+  const { handler, sendCommandCalls } = makeHarness({ localClient: local });
+  handler.updateFromLocal(localStatus({ operationMode: 'heat', spHeat: 20 }));
+
+  await handler.setTargetTemperature(22);
+
+  assert.strictEqual(local.calls.length, 0, 'local not attempted');
+  assert.deepStrictEqual(sendCommandCalls.map((c) => c.commands), [{ spHeat: 22 }], 'cloud used');
+});


### PR DESCRIPTION
## What

Opt-in **local LAN control** (`localControl: true`, default off): the plugin controls and reads each unit directly over the LAN, falling back to the cloud per-unit. Cloud streaming stays connected as the fallback. Modeled on Home Assistant's `mitsubishi_comfort` integration.

Also a **0.1°C setpoint step** (transport-agnostic) that fixes the long-standing app-vs-HomeKit °F mismatch.

## How

- `src/local-api.ts` — pykumo token algorithm (live-verified), `LocalKumoClient` (per-device mutex + forgiving timeout), command/status mapping (`mode`/`vaneDir`, no `power`, 0.1 rounding), and LAN discovery (sweep + token-match, since the cloud gives no IP/MAC).
- Credentials reuse what we already see: local `password` from the `adapter_update` socket event, `cryptoSerial` from `/devices/{serial}/status`.
- `platform.initLocalControl()` (background: wait for creds → resolve IPs → poll), `accessory.sendDeviceCommand()` (local-first, cloud fallback), `accessory.updateFromLocal()`, local-authoritative status (drop cloud while local is fresh ≤45s).
- 0.1°C `minStep` on TargetTemperature + AUTO threshold handles.

## Verification

- **48 `node:test` cases** (`local-api` 13 + `local-integration` 6 + prior 29): token, command builder, status mapping, subnet enumeration, local-first routing, cloud fallback, local-authoritative drop.
- **Live on the Pi:** 5/5 units discovered + controlled locally, polling at 15s, zero errors. The deployed `dist/local-api.js` read Kitchen and sent an accepted command against real hardware. 0.1°C confirmed honored (cloud stored 23.3 exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)