### PR TITLE
fix: don't collapse the AUTO band on a single TargetTemperature write (scenes/Siri)

### DIFF
--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -991,9 +991,20 @@ export class KumoThermostatAccessory {
     } else if (this.currentStatus.operationMode === 'cool') {
       commands.spCool = temp;
     } else if (this.isAutoMode(this.currentStatus.operationMode)) {
-      // For auto mode, set both setpoints
-      commands.spHeat = temp;
-      commands.spCool = temp;
+      // In AUTO the band is governed by HeatingThresholdTemperature (spHeat) and
+      // CoolingThresholdTemperature (spCool) — added in PR #19. HomeKit's
+      // *required* single TargetTemperature has no meaning in AUTO, but scenes and
+      // automations snapshot a thermostat's full state and re-send TargetTemperature
+      // alongside the two thresholds (and Siri "set to X" sends it alone). Collapsing
+      // to spHeat = spCool = temp here flattens the band, and when a scene fires it
+      // races the independent threshold writes from the same burst — so the band
+      // survives or collapses nondeterministically depending on write order.
+      // Ignore the single-target write in AUTO; the threshold handlers are
+      // authoritative for the band.
+      this.platform.log.debug(
+        `[TEMP CHANGE] ${this.accessory.displayName}: ignoring single TargetTemperature write in AUTO (band governed by Heating/CoolingThreshold)`,
+      );
+      return;
     } else if (this.currentStatus.operationMode === 'dry' && this.dryUsesSetpoint()) {
       // Dry holds its setpoint in spCool, not spHeat (Kumo v3; there is no spDry
       // field). Verified live: the spCool write is adopted and the unit stays in

--- a/test/auto-setpoint.test.js
+++ b/test/auto-setpoint.test.js
@@ -234,3 +234,25 @@ test('COOL-mode TargetTemperature still sends spCool (control)', async () => {
 
   assert.deepStrictEqual(sendCommandCalls[0].commands, { spCool: 23 });
 });
+
+// ---- AUTO single-target write must not collapse the band -----------------
+
+// A HomeKit scene/automation snapshots a thermostat's full state and, on
+// activation, re-sends the *required* single TargetTemperature together with the
+// two threshold characteristics. In AUTO, honoring that single target (spHeat =
+// spCool = temp) collapses the band and races the threshold writes from the same
+// burst. In AUTO the thresholds are authoritative, so the single-target write is
+// ignored.
+test('AUTO-mode TargetTemperature write is ignored (scenes/Siri do not collapse the band)', async () => {
+  const { handler, sendCommandCalls } = makeHarness();
+  handler.updateFromZone(zone({ operationMode: 'autoCool', spHeat: 20, spCool: 26 }));
+
+  await handler.setTargetTemperature(22);
+
+  assert.strictEqual(sendCommandCalls.length, 0,
+    'a single TargetTemperature write in AUTO sends nothing (band is governed by the thresholds)');
+  assert.strictEqual(await handler.getHeatingThresholdTemperature(), 20,
+    'the heat edge of the band is untouched');
+  assert.strictEqual(await handler.getCoolingThresholdTemperature(), 26,
+    'the cool edge of the band is untouched');
+});


### PR DESCRIPTION
## What
In AUTO, `setTargetTemperature` no longer collapses the band to `spHeat == spCool`. A lone `TargetTemperature` write in AUTO is ignored; the Heating/CoolingThreshold handlers stay authoritative.

## Why
PR #19 added the dual-setpoint band via the two threshold characteristics but left `setTargetTemperature` untouched. HomeKit's Thermostat has a *required* single `TargetTemperature`, and scenes/automations snapshot a thermostat's full state and re-send `TargetTemperature` together with both thresholds (Siri "set to X" sends it alone). In AUTO the old branch set `spHeat = spCool = temp`, which collapses the band **and** races the independent threshold writes from the same scene burst — so the band survives or collapses nondeterministically depending on write order.

Observed on real hardware (MLZ-KX / MSZ-GX, `spAuto: null`): dragging the two handles holds a band, but firing a scene collapsed some zones to `spHeat==spCool` while others survived — pure write-order luck.

## How
The AUTO branch of `setTargetTemperature` logs at debug and returns; the thresholds govern the band in AUTO. HEAT/COOL/DRY paths unchanged.

## Verification
- New regression test: a single `TargetTemperature` write in AUTO sends no command and leaves both band edges untouched.
- `npm test`: 49 pass / 0 fail; build clean.
- Live: on a patched instance, firing a HomeKit scene across three zones held split bands on all of them; the log shows the new ignore path and no collapse.

## Note
Siri "set to X" while in AUTO now no-ops (previously it collapsed the band). A follow-up could instead interpret a single-target write in AUTO as a band *shift* (recenter around temp); ignoring is the minimal correct fix.
