### PR TITLE
fix: round temperatures to nearest whole °F to eliminate ±1°F offset

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -81,6 +81,16 @@
         "maximum": 60,
         "description": "Fast polling interval when streaming is unhealthy (default: 10 seconds)"
       },
+      "temperatureUnit": {
+        "title": "Temperature Display Unit",
+        "type": "string",
+        "default": "F",
+        "oneOf": [
+          { "title": "Fahrenheit (corrects ±1°F rounding)", "enum": ["F"] },
+          { "title": "Celsius (no correction)", "enum": ["C"] }
+        ],
+        "description": "When set to F (default), temperatures from the API are rounded to the nearest whole Fahrenheit degree before publishing to HomeKit, eliminating the ±1°F display error caused by the Fahrenheit→Celsius→Fahrenheit double-conversion round-trip."
+      },
       "localControl": {
         "title": "Enable Local Control (experimental)",
         "type": "boolean",
@@ -156,6 +166,7 @@
             }
           ]
         },
+        "temperatureUnit",
         "debug"
       ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-mitsubishi-comfort",
-  "version": "1.8.2",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-mitsubishi-comfort",
-      "version": "1.8.2",
+      "version": "1.8.4",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.2.0",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -16,6 +16,18 @@ export type CommandOrigin =
   | 'mirror';
 
 /**
+ * Round a Celsius value to the nearest exact Fahrenheit-whole-degree equivalent.
+ * Eliminates the ±1°F display error in the Home app caused by the
+ * °F→°C (Kumo API) → °C→°F (Home app) double-conversion: e.g. 70°F stored as
+ * 21.0°C reads back as 69.8°F and may display as 69°F. After correction,
+ * 21.0°C → round(69.8)=70°F → (70−32)×5/9 = 21.111°C, which displays as 70°F.
+ */
+function roundToNearestFahrenheit(celsius: number): number {
+  const f = celsius * 9 / 5 + 32;
+  return (Math.round(f) - 32) * 5 / 9;
+}
+
+/**
  * Collapse power + operationMode into the one label that matters for "is it on,
  * and doing what". power=0 is off whatever the mode field says.
  */
@@ -89,6 +101,7 @@ export class KumoThermostatAccessory {
   // thermostat / Kumo app / any observed change) and from the setters (catches a
   // HomeKit change to this unit without waiting for the streaming/local echo).
   private statusListeners: Array<(status: DeviceStatus) => void> = [];
+  private readonly useFahrenheitCorrection: boolean;
 
   constructor(
     private readonly platform: KumoV3Platform,
@@ -96,6 +109,7 @@ export class KumoThermostatAccessory {
     private readonly kumoAPI: KumoAPI,
     pollIntervalSeconds?: number,
   ) {
+    this.useFahrenheitCorrection = (platform.config as any)?.temperatureUnit !== 'C';
     this.deviceSerial = this.accessory.context.device.deviceSerial;
     this.siteId = this.accessory.context.device.siteId;
     this.pollIntervalMs = (pollIntervalSeconds || POLL_INTERVAL / 1000) * 1000;
@@ -197,6 +211,11 @@ export class KumoThermostatAccessory {
       }
     });
 
+  }
+
+  /** Apply Fahrenheit round-trip correction if configured (no-op when disabled). */
+  private correctTemp(celsius: number): number {
+    return this.useFahrenheitCorrection ? roundToNearestFahrenheit(celsius) : celsius;
   }
 
   private applyDeviceProfile(profile: DeviceProfile): void {
@@ -839,7 +858,7 @@ export class KumoThermostatAccessory {
       if (status.roomTemp !== undefined && status.roomTemp !== null && !isNaN(status.roomTemp)) {
         this.service.updateCharacteristic(
           this.platform.Characteristic.CurrentTemperature,
-          status.roomTemp,
+          this.correctTemp(status.roomTemp),
         );
       }
 
@@ -851,7 +870,7 @@ export class KumoThermostatAccessory {
 
         this.service.updateCharacteristic(
           this.platform.Characteristic.TargetTemperature,
-          targetTemp,
+          this.correctTemp(targetTemp),
         );
       }
 
@@ -863,13 +882,13 @@ export class KumoThermostatAccessory {
       if (status.spHeat !== undefined && status.spHeat !== null && !isNaN(status.spHeat)) {
         this.service.updateCharacteristic(
           this.platform.Characteristic.HeatingThresholdTemperature,
-          status.spHeat,
+          this.correctTemp(status.spHeat),
         );
       }
       if (status.spCool !== undefined && status.spCool !== null && !isNaN(status.spCool)) {
         this.service.updateCharacteristic(
           this.platform.Characteristic.CoolingThresholdTemperature,
-          status.spCool,
+          this.correctTemp(status.spCool),
         );
       }
 
@@ -1164,7 +1183,7 @@ export class KumoThermostatAccessory {
     }
 
     this.platform.log.debug(`HomeKit get current temp for ${this.accessory.displayName}: ${temp}°C`);
-    return temp;
+    return this.correctTemp(temp);
   }
 
   async getTargetTemperature(): Promise<CharacteristicValue> {
@@ -1184,7 +1203,7 @@ export class KumoThermostatAccessory {
     }
 
     this.platform.log.debug(`HomeKit get target temp for ${this.accessory.displayName}: ${temp}°C`);
-    return temp;
+    return this.correctTemp(temp);
   }
 
   async setTargetTemperature(value: CharacteristicValue) {
@@ -1315,7 +1334,7 @@ export class KumoThermostatAccessory {
     if (v === undefined || v === null || isNaN(v)) {
       return fallback;
     }
-    return v;
+    return this.correctTemp(v);
   }
 
   async setHeatingThresholdTemperature(value: CharacteristicValue) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,6 +37,11 @@ export interface KumoConfig {
   // Kumo app, or HomeKit), the source's full state is pushed to the target. One-way;
   // a manual change to the target persists until the next source change re-syncs it.
   mirror?: MirrorPair[];
+  // Temperature display unit. When set to 'F', the plugin rounds Celsius values
+  // from the API to the nearest exact Fahrenheit equivalent before publishing to
+  // HomeKit, eliminating the ±1°F display error caused by the °F→°C→°F
+  // double-conversion round-trip. Default 'F' (US-market units).
+  temperatureUnit?: 'F' | 'C';
 }
 
 /** A one-way mirror: `target` follows `source` (both device serials). */

--- a/test/auto-setpoint.test.js
+++ b/test/auto-setpoint.test.js
@@ -103,6 +103,7 @@ function makeHarness() {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
   };
   const kumoAPI = {
     subscribeToDevice() {},

--- a/test/command-origin-logging.test.js
+++ b/test/command-origin-logging.test.js
@@ -63,7 +63,7 @@ function makeAccessory() {
 }
 function makeHarness() {
   const log = makeLog();
-  const platform = { Service, Characteristic, log, api: { updatePlatformAccessories() {} }, localClient: null };
+  const platform = { Service, Characteristic, log, api: { updatePlatformAccessories() {} }, config: { temperatureUnit: 'C' }, localClient: null };
   const kumoAPI = { subscribeToDevice() {}, onDeviceProfileUpdate() {}, sendCommand() { return Promise.resolve(true); } };
   const handler = new KumoThermostatAccessory(platform, makeAccessory(), kumoAPI, 30);
   return { handler, log };

--- a/test/dry-off-thermostat.test.js
+++ b/test/dry-off-thermostat.test.js
@@ -103,6 +103,7 @@ function makeHarness() {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
   };
   const kumoAPI = {
     subscribeToDevice() {},

--- a/test/dry-setpoint.test.js
+++ b/test/dry-setpoint.test.js
@@ -103,6 +103,7 @@ function makeHarness() {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
   };
   const kumoAPI = {
     subscribeToDevice() {},

--- a/test/local-integration.test.js
+++ b/test/local-integration.test.js
@@ -82,6 +82,7 @@ function makeHarness({ localClient = null } = {}) {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
     localClient,
   };
   const kumoAPI = {

--- a/test/mirror-apply.test.js
+++ b/test/mirror-apply.test.js
@@ -75,6 +75,7 @@ function makeHarness() {
   const platform = {
     Service, Characteristic, log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
     localClient: null,
   };
   const kumoAPI = {

--- a/test/mirror-hook.test.js
+++ b/test/mirror-hook.test.js
@@ -45,7 +45,7 @@ function makeAccessory() {
   };
 }
 function makeHarness() {
-  const platform = { Service, Characteristic, log: makeLog(), api: { updatePlatformAccessories() {} }, localClient: null };
+  const platform = { Service, Characteristic, log: makeLog(), api: { updatePlatformAccessories() {} }, config: { temperatureUnit: 'C' }, localClient: null };
   const kumoAPI = {
     subscribeToDevice() {}, onDeviceProfileUpdate() {},
     sendCommand() { return Promise.resolve(true); },

--- a/test/mirror-stale-revive.test.js
+++ b/test/mirror-stale-revive.test.js
@@ -69,7 +69,7 @@ function makeLocalClient(over = {}) {
   };
 }
 function makeHarness({ localClient = null } = {}) {
-  const platform = { Service, Characteristic, log: makeLog(), api: { updatePlatformAccessories() {} }, localClient };
+  const platform = { Service, Characteristic, log: makeLog(), api: { updatePlatformAccessories() {} }, config: { temperatureUnit: 'C' }, localClient };
   const kumoAPI = { subscribeToDevice() {}, onDeviceProfileUpdate() {}, sendCommand() { return Promise.resolve(true); } };
   const handler = new KumoThermostatAccessory(platform, makeAccessory(), kumoAPI, 30);
   return { handler };

--- a/test/off-scene-pre-setpoint.test.js
+++ b/test/off-scene-pre-setpoint.test.js
@@ -82,6 +82,7 @@ function makeHarness() {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
   };
   const kumoAPI = {
     subscribeToDevice() {},

--- a/test/off-scene-setpoint-race.test.js
+++ b/test/off-scene-setpoint-race.test.js
@@ -103,6 +103,7 @@ function makeHarness() {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
   };
   const kumoAPI = {
     subscribeToDevice() {},

--- a/test/setpoint-while-off.test.js
+++ b/test/setpoint-while-off.test.js
@@ -99,6 +99,7 @@ function makeHarness() {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit: 'C' },
   };
   const kumoAPI = {
     subscribeToDevice() {},

--- a/test/switch-publish.test.js
+++ b/test/switch-publish.test.js
@@ -104,6 +104,7 @@ function makeHarness() {
     Characteristic,
     log: makeLog(),
     api: { updatePlatformAccessories: (a) => updates.push(a) },
+    config: { temperatureUnit: 'C' },
   };
   const kumoAPI = {
     subscribeToDevice() {},

--- a/test/temp-rounding.test.js
+++ b/test/temp-rounding.test.js
@@ -1,0 +1,257 @@
+'use strict';
+
+// Test for the Fahrenheit round-trip temperature correction.
+//
+// The Kumo API returns temperatures in Celsius. When the device works internally
+// in Fahrenheit (US-market units), the °F→°C conversion in the API may lose
+// precision (e.g. 70°F stored as 21.0°C instead of 21.111°C). When the Home app
+// converts back (21.0°C → 69.8°F), the displayed value can be 1°F off.
+//
+// The fix rounds each Celsius value to the nearest exact Fahrenheit whole-degree
+// equivalent before publishing to HomeKit, controlled by the `temperatureUnit`
+// config option (default 'F').
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { KumoThermostatAccessory } = require('../dist/accessory.js');
+
+const SERIAL = 'TESTSERIAL001';
+
+function makeLog() {
+  const noop = () => {};
+  return { info: noop, warn: noop, error: noop, debug: noop };
+}
+
+const charCache = {};
+const Characteristic = new Proxy({}, {
+  get(_t, prop) {
+    if (!charCache[prop]) {
+      charCache[prop] = { _name: String(prop), OFF: 0, HEAT: 1, COOL: 2, AUTO: 3, FILTER_OK: 0, CHANGE_FILTER: 1 };
+    }
+    return charCache[prop];
+  },
+});
+
+const Service = {
+  AccessoryInformation: 'AccessoryInformation',
+  Thermostat: 'Thermostat',
+  Switch: 'Switch',
+  FilterMaintenance: 'FilterMaintenance',
+};
+
+function makeCharacteristic() {
+  const ch = {
+    value: undefined,
+    onGet() { return ch; },
+    onSet() { return ch; },
+    setProps() { return ch; },
+  };
+  return ch;
+}
+
+function makeService(type, name, subtype) {
+  const chars = new Map();
+  const svc = {
+    type, name, subtype,
+    getCharacteristic(id) {
+      if (!chars.has(id)) chars.set(id, makeCharacteristic());
+      return chars.get(id);
+    },
+    setCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+    updateCharacteristic(id, v) { svc.getCharacteristic(id).value = v; return svc; },
+  };
+  return svc;
+}
+
+function makeAccessory() {
+  const entries = [
+    { type: Service.AccessoryInformation, subtype: undefined, svc: makeService(Service.AccessoryInformation) },
+  ];
+  return {
+    displayName: 'TestUnit',
+    UUID: 'test-uuid',
+    context: { device: { deviceSerial: SERIAL, siteId: 'site-1', displayName: 'TestUnit' } },
+    getService(type) {
+      const e = entries.find((x) => x.type === type && x.subtype === undefined);
+      return e ? e.svc : null;
+    },
+    addService(type, name, subtype) {
+      const s = makeService(type, name, subtype);
+      entries.push({ type, subtype, svc: s });
+      return s;
+    },
+    getServiceById(type, subtype) {
+      const e = entries.find((x) => x.type === type && x.subtype === subtype);
+      return e ? e.svc : null;
+    },
+    removeService() {},
+  };
+}
+
+function makeKumoAPI() {
+  return {
+    subscribeToDevice() {},
+    unsubscribeFromDevice() {},
+    onDeviceProfileUpdate() {},
+    sendCommand: async () => true,
+  };
+}
+
+function makePlatform(temperatureUnit) {
+  return {
+    log: makeLog(),
+    Service,
+    Characteristic,
+    api: { updatePlatformAccessories() {} },
+    config: { temperatureUnit },
+    localClient: null,
+  };
+}
+
+function buildHandler(temperatureUnit) {
+  const platform = makePlatform(temperatureUnit);
+  const accessory = makeAccessory();
+  const api = makeKumoAPI();
+  const handler = new KumoThermostatAccessory(platform, accessory, api, 30);
+  return { handler, accessory, platform };
+}
+
+function feedZoneUpdate(handler, roomTemp, spHeat, spCool, operationMode) {
+  handler.updateFromZone({
+    id: 'zone-1',
+    name: 'TestUnit',
+    isActive: true,
+    adapter: {
+      id: 'adapter-1',
+      deviceSerial: SERIAL,
+      roomTemp,
+      spHeat,
+      spCool,
+      spAuto: null,
+      humidity: null,
+      power: 1,
+      operationMode: operationMode || 'cool',
+      previousOperationMode: operationMode || 'cool',
+      fanSpeed: 'auto',
+      airDirection: 'auto',
+      connected: true,
+      isSimulator: false,
+      hasSensor: false,
+      hasMhk2: false,
+      scheduleOwner: 'adapter',
+      scheduleHoldEndTime: 0,
+    },
+  });
+}
+
+function getCharValue(accessory, serviceType, charId) {
+  const svc = accessory.getService(serviceType);
+  if (!svc) return undefined;
+  const ch = svc.getCharacteristic(charId);
+  return ch ? ch.value : undefined;
+}
+
+// --- Tests ---
+
+test('roundToNearestFahrenheit corrects 21.0°C to display as 70°F', () => {
+  const { handler, accessory } = buildHandler('F');
+  // 70°F = 21.111°C, API returns 21.0°C which is 69.8°F → without fix shows 69°F
+  feedZoneUpdate(handler, 21.0, 21.0, 21.0, 'cool');
+
+  const currentTemp = getCharValue(accessory, 'Thermostat', Characteristic.CurrentTemperature);
+  const targetTemp = getCharValue(accessory, 'Thermostat', Characteristic.TargetTemperature);
+
+  // After correction: 21.0°C → round(69.8°F) = 70°F → (70-32)*5/9 ≈ 21.111°C
+  const expected = (70 - 32) * 5 / 9;
+  assert.ok(Math.abs(currentTemp - expected) < 0.001,
+    `currentTemp should be ~${expected.toFixed(4)}°C (70°F), got ${currentTemp}`);
+  assert.ok(Math.abs(targetTemp - expected) < 0.001,
+    `targetTemp should be ~${expected.toFixed(4)}°C (70°F), got ${targetTemp}`);
+});
+
+test('no correction when temperatureUnit is C', () => {
+  const { handler, accessory } = buildHandler('C');
+  feedZoneUpdate(handler, 21.0, 21.0, 21.0, 'cool');
+
+  const currentTemp = getCharValue(accessory, 'Thermostat', Characteristic.CurrentTemperature);
+  const targetTemp = getCharValue(accessory, 'Thermostat', Characteristic.TargetTemperature);
+
+  assert.strictEqual(currentTemp, 21.0, 'currentTemp should be raw 21.0°C with no correction');
+  assert.strictEqual(targetTemp, 21.0, 'targetTemp should be raw 21.0°C with no correction');
+});
+
+test('correction is default (no config = treated as F)', () => {
+  const { handler, accessory } = buildHandler(undefined);
+  feedZoneUpdate(handler, 21.0, 21.0, 21.0, 'cool');
+
+  const currentTemp = getCharValue(accessory, 'Thermostat', Characteristic.CurrentTemperature);
+  const expected = (70 - 32) * 5 / 9;
+  assert.ok(Math.abs(currentTemp - expected) < 0.001,
+    `should default to F correction, got ${currentTemp}`);
+});
+
+test('correction round-trips a range of Fahrenheit values', () => {
+  const { handler, accessory } = buildHandler('F');
+
+  // Test a set of common Fahrenheit setpoints and their lossy Celsius representations
+  const cases = [
+    { inputC: 15.5, expectedF: 60 },  // 60°F = 15.556°C
+    { inputC: 18.0, expectedF: 64 },  // 64°F = 17.778°C, but 18.0°C → 64.4°F → 64°F
+    { inputC: 18.5, expectedF: 65 },  // 65°F = 18.333°C
+    { inputC: 20.0, expectedF: 68 },  // 68°F = 20.000°C (exact)
+    { inputC: 20.5, expectedF: 69 },  // 69°F = 20.556°C
+    { inputC: 21.0, expectedF: 70 },  // 70°F = 21.111°C
+    { inputC: 21.5, expectedF: 71 },  // 71°F = 21.667°C
+    { inputC: 22.0, expectedF: 72 },  // 72°F = 22.222°C
+    { inputC: 22.5, expectedF: 73 },  // 73°F = 22.778°C
+    { inputC: 23.0, expectedF: 73 },  // 73°F = 22.778°C, 23.0°C → 73.4°F → 73°F
+    { inputC: 23.5, expectedF: 74 },  // 74°F = 23.333°C
+    { inputC: 24.0, expectedF: 75 },  // 75°F = 23.889°C, 24.0°C → 75.2°F → 75°F
+    { inputC: 25.0, expectedF: 77 },  // 77°F = 25.000°C (exact)
+  ];
+
+  for (const { inputC, expectedF } of cases) {
+    feedZoneUpdate(handler, inputC, inputC, inputC, 'cool');
+    const currentTemp = getCharValue(accessory, 'Thermostat', Characteristic.CurrentTemperature);
+    const resultF = Math.round(currentTemp * 9 / 5 + 32);
+    assert.strictEqual(resultF, expectedF,
+      `${inputC}°C should display as ${expectedF}°F, got ${resultF}°F (corrected to ${currentTemp.toFixed(4)}°C)`);
+  }
+});
+
+test('threshold temperatures are also corrected', () => {
+  const { handler, accessory } = buildHandler('F');
+  // In auto mode, both spHeat and spCool are published as threshold temps
+  feedZoneUpdate(handler, 21.0, 20.0, 23.0, 'autoHeat');
+
+  const heatThreshold = getCharValue(accessory, 'Thermostat', Characteristic.HeatingThresholdTemperature);
+  const coolThreshold = getCharValue(accessory, 'Thermostat', Characteristic.CoolingThresholdTemperature);
+
+  // 20.0°C → 68°F → (68-32)*5/9 = 20.0°C (exact, no change needed)
+  const expectedHeatF = 68;
+  const actualHeatF = Math.round(heatThreshold * 9 / 5 + 32);
+  assert.strictEqual(actualHeatF, expectedHeatF,
+    `heat threshold 20.0°C should display as ${expectedHeatF}°F, got ${actualHeatF}°F`);
+
+  // 23.0°C → 73.4°F → round to 73°F → (73-32)*5/9 ≈ 22.778°C
+  const expectedCoolF = 73;
+  const actualCoolF = Math.round(coolThreshold * 9 / 5 + 32);
+  assert.strictEqual(actualCoolF, expectedCoolF,
+    `cool threshold 23.0°C should display as ${expectedCoolF}°F, got ${actualCoolF}°F`);
+});
+
+test('internal currentStatus is NOT modified by the correction', () => {
+  const { handler, accessory } = buildHandler('F');
+  feedZoneUpdate(handler, 21.0, 21.0, 23.0, 'cool');
+
+  // The characteristic value should be corrected
+  const displayTemp = getCharValue(accessory, 'Thermostat', Characteristic.CurrentTemperature);
+  assert.notStrictEqual(displayTemp, 21.0, 'display value should be corrected away from 21.0');
+
+  // But getCurrentTemperature should also return the corrected value (it reads from
+  // cache and corrects at the boundary)
+  handler.getCurrentTemperature().then(val => {
+    const resultF = Math.round(val * 9 / 5 + 32);
+    assert.strictEqual(resultF, 70, 'getCurrentTemperature getter should also return corrected value');
+  });
+});


### PR DESCRIPTION
## Summary

- The Home app shows temperatures ±1°F off from the Kumo/Mitsubishi app due to a double-conversion rounding artifact: the API stores °F internally, returns °C, and HomeKit converts back to °F — losing precision in the round-trip.
- Adds `roundToNearestFahrenheit()` applied at the HomeKit publish boundary (not modifying internal state) that snaps each °C value to the nearest value displaying as the correct whole °F.
- Controlled by a new `temperatureUnit` config option (default `'F'`); set to `'C'` to disable for users with Celsius-native systems.

## Details

The correction is applied at 7 points where temperatures are published to HomeKit characteristics:
- `CurrentTemperature` (room temp)
- `TargetTemperature` (single setpoint in HEAT/COOL/DRY)
- `HeatingThresholdTemperature` (AUTO low handle)
- `CoolingThresholdTemperature` (AUTO high handle)
- Corresponding getter methods

Internal `currentStatus` is never modified — the correction is purely at the HomeKit display boundary.

## Test plan

- [x] 6 new tests in `test/temp-rounding.test.js` covering the rounding function, config-driven behavior, threshold temps, and internal state preservation
- [x] All 128 tests pass (existing + new)
- [ ] Verify in the Home app that temperatures now match the Kumo app exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)